### PR TITLE
Add membership sales analysis issue #8

### DIFF
--- a/notebooks/membership_sales_analysis.ipynb
+++ b/notebooks/membership_sales_analysis.ipynb
@@ -1,0 +1,378 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "a4683e36",
+   "metadata": {},
+   "source": [
+    "# introduction\n",
+    "The objective of this analysis is to evaluate the relationship between customer membership status (Normal vs. Premium) and financial performance. By isolating the sales data attached to different membership tiers, we aim to understand which customer segment drives the most revenue and determine the value proposition of the Premium membership program."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "01c9b13e",
+   "metadata": {},
+   "source": [
+    "# Methodology\n",
+    "1. **Data Loading**: The dataset was imported using Pandas.\n",
+    "\n",
+    "2. **Filtering**: The data was filtered to exclude rows where membership was labeled \"Not Logged In\" to ensure the comparison focuses strictly on established membership tiers.\n",
+    "\n",
+    "3. **Grouping**: The data was grouped by the membership column.\n",
+    "\n",
+    "4. **Aggregation**: We calculated the Total Sales (sum) to understand total volume. Note: The code below also adds a calculation for Average Sales (mean) to evaluate transaction value, which was a requested task not fully calculated in the original cells.\n",
+    "\n",
+    "5. **Visualization**: A bar chart was generated to visually compare the revenue contribution of each group."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "aa96c037",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "920ee36e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "<>:1: SyntaxWarning: \"\\E\" is an invalid escape sequence. Such sequences will not work in the future. Did you mean \"\\\\E\"? A raw string is also an option.\n",
+      "<>:1: SyntaxWarning: \"\\E\" is an invalid escape sequence. Such sequences will not work in the future. Did you mean \"\\\\E\"? A raw string is also an option.\n",
+      "C:\\Users\\nayan\\AppData\\Local\\Temp\\ipykernel_26064\\3889678885.py:1: SyntaxWarning: \"\\E\" is an invalid escape sequence. Such sequences will not work in the future. Did you mean \"\\\\E\"? A raw string is also an option.\n",
+      "  df = pd.read_csv(\"..\\E-commerce_dataset.csv\")\n",
+      "C:\\Users\\nayan\\AppData\\Local\\Temp\\ipykernel_26064\\3889678885.py:1: DtypeWarning: Columns (6) have mixed types. Specify dtype option on import or set low_memory=False.\n",
+      "  df = pd.read_csv(\"..\\E-commerce_dataset.csv\")\n"
+     ]
+    },
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>accessed_date</th>\n",
+       "      <th>duration_(secs)</th>\n",
+       "      <th>network_protocol</th>\n",
+       "      <th>ip</th>\n",
+       "      <th>bytes</th>\n",
+       "      <th>accessed_Ffom</th>\n",
+       "      <th>age</th>\n",
+       "      <th>gender</th>\n",
+       "      <th>country</th>\n",
+       "      <th>membership</th>\n",
+       "      <th>language</th>\n",
+       "      <th>sales</th>\n",
+       "      <th>returned</th>\n",
+       "      <th>returned_amount</th>\n",
+       "      <th>pay_method</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2017-03-14 17:43:57</td>\n",
+       "      <td>2533</td>\n",
+       "      <td>TCP</td>\n",
+       "      <td>1.10.195.126</td>\n",
+       "      <td>20100</td>\n",
+       "      <td>Chrome</td>\n",
+       "      <td>28</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>CA</td>\n",
+       "      <td>Normal</td>\n",
+       "      <td>English</td>\n",
+       "      <td>261.96</td>\n",
+       "      <td>No</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>Credit Card</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2017-03-14 17:43:57</td>\n",
+       "      <td>4034</td>\n",
+       "      <td>TCP</td>\n",
+       "      <td>1.1.217.211</td>\n",
+       "      <td>20500</td>\n",
+       "      <td>Mozilla Firefox</td>\n",
+       "      <td>21</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>AR</td>\n",
+       "      <td>Normal</td>\n",
+       "      <td>English</td>\n",
+       "      <td>731.94</td>\n",
+       "      <td>No</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>Debit Card</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2017-03-14 17:43:26</td>\n",
+       "      <td>1525</td>\n",
+       "      <td>TCP</td>\n",
+       "      <td>1.115.198.107</td>\n",
+       "      <td>90100</td>\n",
+       "      <td>Mozilla Firefox</td>\n",
+       "      <td>20</td>\n",
+       "      <td>Male</td>\n",
+       "      <td>PL</td>\n",
+       "      <td>Normal</td>\n",
+       "      <td>English</td>\n",
+       "      <td>14.62</td>\n",
+       "      <td>No</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>Cash</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2017-03-14 17:43:26</td>\n",
+       "      <td>4572</td>\n",
+       "      <td>TCP</td>\n",
+       "      <td>1.121.152.143</td>\n",
+       "      <td>100300</td>\n",
+       "      <td>Mozilla Firefox</td>\n",
+       "      <td>66</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>IN</td>\n",
+       "      <td>Normal</td>\n",
+       "      <td>Spanish</td>\n",
+       "      <td>957.58</td>\n",
+       "      <td>No</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>Credit Card</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2017-03-14 18:17:09</td>\n",
+       "      <td>3652</td>\n",
+       "      <td>TCP</td>\n",
+       "      <td>1.123.135.213</td>\n",
+       "      <td>270200</td>\n",
+       "      <td>Mozilla Firefox</td>\n",
+       "      <td>53</td>\n",
+       "      <td>Female</td>\n",
+       "      <td>KR</td>\n",
+       "      <td>Normal</td>\n",
+       "      <td>Spanish</td>\n",
+       "      <td>22.37</td>\n",
+       "      <td>No</td>\n",
+       "      <td>0.00</td>\n",
+       "      <td>Cash</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "         accessed_date  duration_(secs) network_protocol             ip  \\\n",
+       "0  2017-03-14 17:43:57             2533              TCP   1.10.195.126   \n",
+       "1  2017-03-14 17:43:57             4034              TCP    1.1.217.211   \n",
+       "2  2017-03-14 17:43:26             1525              TCP  1.115.198.107   \n",
+       "3  2017-03-14 17:43:26             4572              TCP  1.121.152.143   \n",
+       "4  2017-03-14 18:17:09             3652              TCP  1.123.135.213   \n",
+       "\n",
+       "    bytes    accessed_Ffom age  gender country membership language  sales  \\\n",
+       "0   20100           Chrome  28  Female      CA     Normal  English 261.96   \n",
+       "1   20500  Mozilla Firefox  21    Male      AR     Normal  English 731.94   \n",
+       "2   90100  Mozilla Firefox  20    Male      PL     Normal  English  14.62   \n",
+       "3  100300  Mozilla Firefox  66  Female      IN     Normal  Spanish 957.58   \n",
+       "4  270200  Mozilla Firefox  53  Female      KR     Normal  Spanish  22.37   \n",
+       "\n",
+       "  returned  returned_amount   pay_method  \n",
+       "0       No             0.00  Credit Card  \n",
+       "1       No             0.00   Debit Card  \n",
+       "2       No             0.00         Cash  \n",
+       "3       No             0.00  Credit Card  \n",
+       "4       No             0.00         Cash  "
+      ]
+     },
+     "execution_count": 160,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df = pd.read_csv(\"..\\E-commerce_dataset.csv\")\n",
+    "df.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "874d954b",
+   "metadata": {},
+   "source": [
+    "# Total sales\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 163,
+   "id": "f7d89a81",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "membership\n",
+       "Normal    22,694,861.35\n",
+       "Premium   48,401,436.17\n",
+       "Name: sales, dtype: float64"
+      ]
+     },
+     "execution_count": 163,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "total_sales = df.groupby(\"membership\")[\"sales\"].sum()\n",
+    "pd.options.display.float_format = '{:,.2f}'.format\n",
+    "df = df[df[\"membership\"] != \"Not Logged In\"]\n",
+    "total_sales\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 164,
+   "id": "3f9eb4f3",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAmcAAAH2CAYAAAA1YCtqAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjcsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvTLEjVAAAAAlwSFlzAAAPYQAAD2EBqD+naQAAPtpJREFUeJzt3QmczXX////XGIaxzWDsYQghO1lKSWSJIipKJZQUWSPjki01lquyJOrqsrS4LH1TlpBsFWNPJIRsEUNirGOZ87+93rf/5/zOmRljxoxz3pzH/XY71znn83mfz3mfzzHXefbePkEul8slAAAAsEImf1cAAAAA/w/hDAAAwCKEMwAAAIsQzgAAACxCOAMAALAI4QwAAMAihDMAAACLEM4AAAAsQjgDAACwCOEMwE21cuVKCQoKMve+9uCDD5qbL+ln7d69uwS6oUOHmnNx4sQJscH+/ftNff7973+nuu6AvxDOgNuQ/rCk5paawPTOO+/I119/7ZN6b9u2TZ544gkpUaKEZMuWTYoWLSoPP/ywTJgwwSfvf6sFXr19/vnnyZa57777zP6KFSv6vH4A0idzOl8PwEKfffaZ1/NPP/1Uli5dmmR7+fLlUxXONDC1atVKbqY1a9ZIgwYNpHjx4vLSSy9JoUKF5NChQ7J27VoZN26cvPbaazf1/W9FGmBnzJghzz77bJJWIj2fuh9pN2jQIBkwYACnDn5DOANuQ4l/rDXgaDhLvN0mb7/9toSFhcmGDRskPDzca19sbKzf6mWzRx55RObNm2e6DiMiItzbNbAVLFhQypQpI//884/czs6fPy/Zs2fP0GNmzpzZ3AB/oVsTCFDnzp2Tvn37SrFixSRr1qxy1113mfE4LpfLXUa7xbTc9OnT3d1oL7zwgtl34MABefXVV83rQkNDJV++fPLkk0+aVpsbsXfvXrn77ruTBDNVoEABr+dTp06Vhx56yGzXuleoUEEmTZqUqveJj4+XIUOGSOnSpc1r9fP379/fbPekYbZevXqmPjlz5jSfc+DAgan+PF988YV5jbZe1ahRQ3744Qf3vhUrVphzOXfu3CSv02Cl+2JiYq77Hi1btjSfYc6cOUmO8dRTT0lwcHCyr9OuUK2Tfm958+aVdu3amVZKTzpWT7tEt27dKvXr1zcBSM/Zl19+afavWrVKateubY6hn/P7779P9r00OGpdcufObf6N9OzZUy5evJiuOm3atEkeeOABUyfnO9m4caM0adLEhFQ9RsmSJaVTp07J1unjjz+WO++805y7e+65x/wHwfXGnDljCVP6XoGMwn8aAAFIA9hjjz1mQkLnzp2latWqsmTJEunXr58cPnxY3n//fVNOu0FffPFFqVWrlnTp0sVs0x81pT9o2nWmP6J33HGHCWUakPQH9Lfffktza4aOM9NA8uuvv153nJS+jwY5/QzawjF//nwTFBMSEqRbt27XfJ3u19f89NNP5vNot66Oc9PP+/vvv7vH1m3fvl1atGghlStXluHDh5sf8T179sjq1atT9Vk0uMyaNUt69OhhXvvhhx9K06ZNZf369eaz6TnSUKg/9I8//rjXa3WbnuO6dete9330HGtA+9///ievvPKK2fbLL7+Y+n/yyScmWCXXQvnmm2+awKTf7fHjx82YPg07P//8s1c41lY3PQ/6HWvw1vOuj7WOvXr1kq5du8ozzzwjY8aMMV3fGqZy5crl9X76PpGRkRIdHW1acMePH2+Oq13tN1Knv//+W5o1a2bqoS3B2kKoLauNGzeW/Pnzm+5ILa//Hr/66qskn1+D65kzZ+Tll182gWv06NHSunVr+eOPPyRLlizp+l6BDOMCcNvr1q2bNoe5n3/99dfm+YgRI7zKPfHEE66goCDXnj173Nty5Mjh6tChQ5Jjnj9/Psm2mJgYc9xPP/3UvW3FihVmm96n5LvvvnMFBwebW926dV39+/d3LVmyxHXp0qVUvXeTJk1cpUqV8tpWv359c3N89tlnrkyZMrl+/PFHr3KTJ082dVy9erV5/v7775vnx48fd6WVvk5vGzdudG87cOCAK1u2bK7HH3/cvS0qKsqVNWtW16lTp9zbYmNjXZkzZ3YNGTIkxfdwzumcOXNcCxYsMN/ZwYMHzb5+/fq5z4N+9rvvvtv9uv3795vz+/bbb3sdb9u2beZ9Pbfra/U9ZsyY4d62c+dOs03P4dq1a93b9XvS7VOnTnVv08+g2x577DGv93r11VfN9l9++eWG66Tfl6e5c+ea7Rs2bLjmOdu3b58pky9fPtfJkyfd27/55huzff78+UnqfiPfK5AR6NYEAtC3335rury0BcCTdnPq79CiRYuuewztOnJcvnzZtGhot5e2WmzevDnNddJZmdpypi1b2vqjLRraTaUzNnVc1bXe+/Tp06brTLvetPVDn1+Ldv9pa1m5cuXMa5ybdpEqbUlUTkvNN998Y1rb0kpbvbTLy6GTHLSFS1snr169arY9//zzpivV6SZU2ipz5cqVNI0N1BYj7QacOXOm+e70/umnn062rLYk6efRFirPz6+TL3R8mvP5Hdqdqy1UDu3O03Oj51C7NB3OYz3/iSVuyXQmdui/wRupk7ZYdezY0Wub830tWLDA/FtMSdu2bSVPnjzu5/fff/81634j3yuQEQhnQADS8WJFihRJ0gXlzN7U/ddz4cIFGTx4sHvMmo710W6lU6dOpRiQUqLjf/THWru9tKsoKirKdEFpl5l2lTq0e7FRo0aSI0cO88Os7+uMPUrpvXfv3m26/LS8561s2bJeEw/0B1yXotAuNu0204Aye/bsVAc1DRWJ6Xvo4HXtslMaEPXzahehQx/XqVPHhNzU0q447XLU7jod/6Rdi9rVeK3PrwFO65f4HOzYsSPJxAvtrk489konbeh3nnibSm7yQeJzoV22mTJlco9NTGudNKyHhIR4bdNg3qZNGxk2bJj5d6iBScclJh5H6AQqT05QS83EidR8r0BGYMwZgBuiLSD6A6hjj7RFQX+g9Ydcg8yNtDZ50h9fDS560x8/bSnRVi8dyK8TBxo2bGjCzXvvvWeCgpbXlhgdO5bSe+u+SpUqmdclxwkd2jKnQUdbbRYuXCiLFy82rVrawvbdd99dc6B9WmnrmQ6Q//PPP02Q0DFZH3zwQZqPo2Fs8uTJZiB7lSpVzASJa31+/Y60ZTS5z6AtZZ6u9Tmvtd1zMsm1JA57aa2TZ6up5zG1BVLPn44/1JYsnQzw7rvvmm2ex0hP3QFfIZwBAUgH3+vsOm2V8mw927lzp3u/41orpeuPYYcOHcwPoENn4WnLWUaqWbOmuf/rr7/Mvf74apDRrk7PVpDE3V/J0VYb7TLVcHe9FeC1dUfL6U3DnK739q9//cu8j7bapURbgxLTCQc6gF9bhBwaZPv06WMG9GtLpLaCaatdWumsUj0XujjtqFGjUvz8GkJ0JqPTWniz6bnQ93PoxAoNZDpJIKPrpK2OetMJBtqS2L59e9PNqy2gGSG13yuQXnRrAgG6PpaOkUncSqMtTxpadDacQ7sOkwtc2gKRuLVBZ9jd6NgbDT3JtV44Y5N0vJPzvsqzrHZlaive9ei4Jp2N+p///CfJPg1HumyIOnnyZJL9OqNVJddVlpiOnfMcd6ddjTp+TceHebbcaBecnmtdRkK7NHXmn+d6Zaml35nOgtSWxeeee+6a5XRWor6/dv8lPtf6XMcNZrSJEyd6PXeu9uD8G8uIOmmXZOLXpuX7Sq3Ufq9AetFyBgSgRx991KzGry1BOvZHu8K0u05/aLSb0lkuQ+kAaG1l09YjHaemLRw6AFyXWNClNrQ7U7vR9IdLy+laVjfaTapjd3RpCe2yvHTpklmqQ7sTtZXFGQSuP4TajamfQZdDOHv2rAlbuuaZ07p2LRpcdOyYLgGhYVDHlWmY1BZD3a7dYdpSp8tnaLdm8+bNTSuijnvSZRN0DJa2Ul2PLqugkxk8l1xQGkCS69rUMXXqrbfekhul46z0lhL9XkeMGGHG8un3rld90JbTffv2mTXXdHmR119/XTKSHlsneWjw1H8jGkS1G1b/zWVUnXQdPj3H+m9Hj6ctwvpvQtdW0/8QyShp+V6BdMmQOZ8AbqmlNNSZM2dcvXv3dhUpUsSVJUsWV5kyZVxjxoxxJSQkeJXT5RMeeOABV2hoqDmGs6zGP//84+rYsaMrIiLClTNnTrOUhZYtUaKE19IbqV1KY9GiRa5OnTq5ypUrZ44XEhLiKl26tOu1115zHTt2zKvsvHnzXJUrVzbLGERGRrpGjRrlmjJlinkfXTLhWktpKF2aQ8vrEhO6lEWePHlcNWrUcA0bNsx1+vRpU2bZsmWuli1bmnOj9dD7p59+2vX7779f91xrHfR8f/755+ac6ntUq1btmp8/Pj7e1CEsLMx14cIFV2p4LqWRksRLaTj+7//+z1WvXj2zTIre9JxrnXft2nXd1+r327x582t+7sTLUfz2229miZZcuXKZz9m9e/dkP2d66rR582bz/RQvXtyc7wIFCrhatGjhteyFs5SG/htPru6ey5dcaymNtHyvQHoE6f+kL94BAG6ULp2hLZLaEvjf//6XE2kp7TrWZUFuZMIGkFaMOQMAP9KrEugyDNq9CQCKMWcA4Afr1q0zl1fScWbVqlUza3UBgKLlDAD8QK9TqdfD1IkMnteZBADGnAEAAFiEljMAAACLMObsFqMrax85csSsA3S9Fc4BAIAddHEMXYNPZ2frFUhSQji7xWgwS3zRYQAAcGvQK0vogtYpIZzdYpzrIOqXq6tfAwAA+8XFxZnGFc/rGV8L4ewW43RlajAjnAEAcGtJzZAkv04IGDp0qKmk502vqee4ePGiWZFZr9WXM2dOadOmjRw7dszrGAcPHjTXv8uePbuZkt6vXz+z4ranlStXSvXq1c210EqXLi3Tpk1L9uK8ev2+bNmymesGrl+/3mu/L+sCAAACl99na959993mYsXO7aeffnLv6927t8yfP1/mzJkjq1atMuOtWrdu7d6vFyzWMORcIFkvfqthZ/Dgwe4yevFcLaMXed6yZYu5qPOLL75oLnDs0Asr9+nTR4YMGSKbN282F+TVi9vqxY59XRcAABDgXH6kF5etUqVKsvtOnTplLsbseWHfHTt2mIvPxsTEmOfffvutK1OmTK6jR4+6y0yaNMmVO3duczFh1b9//yQXym3btq25SLOjVq1aXhfsvXr1qrnQcXR0tM/rktjFixfNxZid26FDh8z7OhdoBgAA9tPf7dT+fvu95Wz37t1mWmmpUqWkffv2pmtQbdq0SS5fviyNGjVyl9Uuz+LFi0tMTIx5rveVKlWSggULustoi5cOutu+fbu7jOcxnDLOMbSlS9/Ls4xOcdXnThlf1SU50dHREhYW5r4xUxMAgNubX8OZju3Srr/FixebS5lot9/9999v1gE5evSohISESHh4uNdrNPzoPqX3nmHI2e/sS6mMhqYLFy7IiRMnTJdkcmU8j+GLuiQnKipKTp8+7b7pLE0AAHD78utszWbNmrkfV65c2YS1EiVKyOzZsyU0NNSfVbOGThzQGwAACAx+79b0pC1TZcuWlT179kihQoVMl+OpU6e8yugMSd2n9D7xjEnn+fXK6DIUGgAjIiIkODg42TKex/BFXQAAAKwKZ2fPnpW9e/dK4cKFpUaNGpIlSxZZtmyZe/+uXbvMmLS6deua53q/bds2r1mVS5cuNWGnQoUK7jKex3DKOMfQ7kp9L88yeokkfe6U8VVdAAAA/Dpbs2/fvq6VK1e69u3b51q9erWrUaNGroiICFdsbKzZ37VrV1fx4sVdy5cvd23cuNFVt25dc3NcuXLFVbFiRVfjxo1dW7ZscS1evNiVP39+V1RUlLvMH3/84cqePburX79+ZoblxIkTXcHBwaasY+bMma6sWbO6pk2b5vrtt99cXbp0cYWHh3vNvPRVXTJytgcAALBDWn6//RrOdBmJwoULu0JCQlxFixY1z/fs2ePef+HCBderr77qypMnjwk1jz/+uOuvv/7yOsb+/ftdzZo1c4WGhppgp4Hv8uXLXmVWrFjhqlq1qnmfUqVKuaZOnZqkLhMmTDDhS8vo0hpr16712u/LuqSEcAYAwK0nLb/fQfo/NCDeOnRmpy6poTM3uXwTAAC33++3VWPOAAAAAh3hDAAAwCKEMwAAAIsQzgAAACzi1ysEAACgIgcs5EQEkP0jm/u7Claj5QwAAMAihDMAAACLEM4AAAAsQjgDAACwCOEMAADAIoQzAAAAixDOAAAALEI4AwAAsAjhDAAAwCKEMwAAAIsQzgAAACxCOAMAALAI4QwAAMAihDMAAACLEM4AAAAsQjgDAACwCOEMAADAIoQzAAAAixDOAAAALEI4AwAAsAjhDAAAwCKEMwAAAIsQzgAAACxCOAMAALAI4QwAAMAihDMAAACLEM4AAAAsQjgDAACwCOEMAADAIoQzAAAAixDOAAAALEI4AwAAsAjhDAAAwCKEMwAAAIsQzgAAACxCOAMAALAI4QwAAMAihDMAAACLEM4AAAAsQjgDAACwCOEMAADAIoQzAAAAixDOAAAALEI4AwAAsAjhDAAAwCKEMwAAAIsQzgAAACxCOAMAALAI4QwAAMAihDMAAACLEM4AAAAsQjgDAACwCOEMAADAIoQzAAAAixDOAAAALEI4AwAAsAjhDAAAwCLWhLORI0dKUFCQ9OrVy73t4sWL0q1bN8mXL5/kzJlT2rRpI8eOHfN63cGDB6V58+aSPXt2KVCggPTr10+uXLniVWblypVSvXp1yZo1q5QuXVqmTZuW5P0nTpwokZGRki1bNqldu7asX7/ea78v6wIAAAKXFeFsw4YN8tFHH0nlypW9tvfu3Vvmz58vc+bMkVWrVsmRI0ekdevW7v1Xr141YejSpUuyZs0amT59ugk7gwcPdpfZt2+fKdOgQQPZsmWLCX8vvviiLFmyxF1m1qxZ0qdPHxkyZIhs3rxZqlSpIk2aNJHY2Fif1wUAAAS2IJfL5fJnBc6ePWtakj788EMZMWKEVK1aVcaOHSunT5+W/Pnzy4wZM+SJJ54wZXfu3Cnly5eXmJgYqVOnjixatEhatGhhglLBggVNmcmTJ8sbb7whx48fl5CQEPN44cKF8uuvv7rfs127dnLq1ClZvHixea4tZffcc4988MEH5nlCQoIUK1ZMXnvtNRkwYIBP65JYfHy8uTni4uJM3bROuXPnvgnfCAD4XuSAhZz2ALJ/ZHMJNHFxcRIWFpaq32+/t5xpV6G2JjVq1Mhr+6ZNm+Ty5cte28uVKyfFixc3gUjpfaVKldxhSGmLl56A7du3u8skPraWcY6hLV36Xp5lMmXKZJ47ZXxVl+RER0ebL9O5aTADAAC3L7+Gs5kzZ5puRA0giR09etS0NoWHh3tt1/Cj+5wynmHI2e/sS6mMhqYLFy7IiRMnTJdkcmU8j+GLuiQnKirKpGzndujQoWTLAQCA20Nmf72xhoyePXvK0qVLzSB8JE8nDugNAAAEBr+1nGlXoQ641/FmmTNnNjcdaD9+/HjzWFuUtMtRx2N50hmShQoVMo/1PvGMSef59cpof29oaKhERERIcHBwsmU8j+GLugAAAPgtnDVs2FC2bdtmZi06t5o1a0r79u3dj7NkySLLli1zv2bXrl1muYq6deua53qvx/CcVaktcRp2KlSo4C7jeQynjHMM7a6sUaOGVxmdEKDPnTK63xd1AQAA8Fu3Zq5cuaRixYpe23LkyGHWEXO2d+7c2SxxkTdvXhNydPakBhmdHakaN25sgs9zzz0no0ePNmO6Bg0aZCYZOF2BXbt2NbMw+/fvL506dZLly5fL7NmzzaxJh75Hhw4dTCCsVauWmS167tw56dixo9mvA/F9VRcAABDY/BbOUuP99983Myd1wVddTkJnNuqSGw7tjlywYIG88sorJihpuNOQNXz4cHeZkiVLmvCj65SNGzdO7rjjDvnkk0/MsRxt27Y1y13ommQaqnQ5D13awnPwvq/qAgAAApvf1znDzVsnBQBuFaxzFlhY5yy33eucAQAA4P8hnAEAAFiEcAYAAGARwhkAAIBFCGcAAAAWIZwBAABYhHAGAABgEcIZAACARQhnAAAAFiGcAQAAWIRwBgAAYBHCGQAAgEUIZwAAABYhnAEAAFiEcAYAAGARwhkAAIBFCGcAAAAWIZwBAABYhHAGAABgEcIZAACARQhnAAAAFiGcAQAAWIRwBgAAYBHCGQAAgEUIZwAAABYhnAEAAFiEcAYAAGARwhkAAIBFCGcAAAAWIZwBAABYhHAGAABgEcIZAACARQhnAAAAFiGcAQAAWIRwBgAAYBHCGQAAgEUIZwAAABYhnAEAAFiEcAYAAGARwhkAAIBFCGcAAAAWIZwBAABYhHAGAABgEcIZAACARQhnAAAAFiGcAQAAWIRwBgAAYBHCGQAAgEUIZwAAABYhnAEAAFiEcAYAAGARwhkAAIBFCGcAAAAWIZwBAABYhHAGAABgEcIZAACARQhnAAAAFiGcAQAAWIRwBgAAYBHCGQAAgEUIZwAAABbxazibNGmSVK5cWXLnzm1udevWlUWLFrn3X7x4Ubp16yb58uWTnDlzSps2beTYsWNexzh48KA0b95csmfPLgUKFJB+/frJlStXvMqsXLlSqlevLlmzZpXSpUvLtGnTktRl4sSJEhkZKdmyZZPatWvL+vXrvfb7si4AACBw+TWc3XHHHTJy5EjZtGmTbNy4UR566CFp2bKlbN++3ezv3bu3zJ8/X+bMmSOrVq2SI0eOSOvWrd2vv3r1qglDly5dkjVr1sj06dNN2Bk8eLC7zL59+0yZBg0ayJYtW6RXr17y4osvypIlS9xlZs2aJX369JEhQ4bI5s2bpUqVKtKkSROJjY11l/FVXQAAQGALcrlcrvQcQEPJtm3bpESJEpInT550Vyhv3rwyZswYeeKJJyR//vwyY8YM81jt3LlTypcvLzExMVKnTh3TytaiRQsTlAoWLGjKTJ48Wd544w05fvy4hISEmMcLFy6UX3/91f0e7dq1k1OnTsnixYvNc20pu+eee+SDDz4wzxMSEqRYsWLy2muvyYABA+T06dM+q8v1xMXFSVhYmKmTtjYCwO0gcsBCf1cBPrR/ZPOAO99xafj9TnPLmbb2/Pe//3UHs/r165tuOg0z2mV3o/RYM2fOlHPnzpnuTW1Nu3z5sjRq1Mhdply5clK8eHETiJTeV6pUyR2GlLZ46QlwWt+0jOcxnDLOMbSlS9/Ls0ymTJnMc6eMr+qSnPj4eHMMzxsAALh9pTmcffnll6bbT2k3n3bVaSuSdvv961//SnMFtNVNx3DpGKyuXbvK3LlzpUKFCnL06FHT2hQeHu5VXsOP7lN67xmGnP3OvpTKaMi5cOGCnDhxwgTD5Mp4HsMXdUlOdHS0SdrOTUMwAAC4faU5nGmYKVSokHn87bffypNPPilly5aVTp06maCVVnfddZcZf7Vu3Tp55ZVXpEOHDvLbb7+l+Ti3q6ioKNME6twOHTrk7yoBAACbwpm29Gh40tYmHSf18MMPm+3nz5+X4ODgNFdAW6R01mKNGjVMK5G2yo0bN84EQO1y1PFYnnSGpBMO9T7xjEnn+fXKaH9vaGioREREmHonV8bzGL6oS3K0RdGZzercAADA7SvN4axjx47y1FNPScWKFSUoKMg9hkpbvnQcVnrpYHwdZ6VhLUuWLLJs2TL3vl27dpnlKnRMmtJ7ba3znFW5dOlSE2C0a9Qp43kMp4xzDA2H+l6eZbQO+twp46u6AAAAZE7rKRg6dKgJZtq9pl2a2rKjtPVJZzamtcuuWbNmZmD9mTNnzGxInVSgS0vo+KrOnTubJS50BqeGHJ09qUFGZ0eqxo0bm+Dz3HPPyejRo82YrkGDBpn1yJx66Tg2nYXZv39/0/W6fPlymT17tpk16dD30O7UmjVrSq1atWTs2LFmYoIGUeXLugAAgMCW5nCmnOUkdGFWh4abtNJWpueff17++usvE4B0QVoNZk5X6fvvv29mTuqCr9qapjMbP/zwQ/frNRAuWLDAjFXToJQjRw5Tj+HDh7vLlCxZ0oQfnbCg3aW6ttonn3xijuVo27atWe5C1yTTUFW1alXTZes5eN9XdQEAAIEtzeuc6Vizd955x6zhpeOlfv/9dylVqpS8+eabZoV9bWHCzcM6ZwBuR6xzFlhY5yx3xo45e/vtt83K99p1p+O1HNrVqa1AAAAAuHFpDmeffvqpfPzxx9K+fXuv2Zk6y1LXOwMAAIAPw9nhw4fN0heJ6QxHXUUfAAAAPgxnOiPxxx9/TPbKAdWqVUtHVQAAAJDm2Zo6o1FnIWoLmraWffXVV2bNL+3u1NmKAAAA8GHLWcuWLc01Nb///nuzXISGtR07dphtzhIYAAAA8OE6Z/fff79Z2R4AAAB+bjkDAACAn1vO8uTJY66jmRonT55Mb50AAAACVqrCmV5rEgAAAJaEsxu5biYAAAB8NCHAoRc+v3Tpkte23Ne5XhQAAAAycELAuXPnpHv37lKgQAGzlIaOR/O8AQAAwIfhrH///rJ8+XKZNGmSZM2a1VzsfNiwYVKkSBGzEC0AAAB82K2pi81qCHvwwQelY8eOZs0zvdZmiRIl5IsvvjAXRAcAAICPWs50qYxSpUq5x5c5S2fUq1dPfvjhhxusBgAAAG4onGkw27dvn3lcrlw5mT17trtFLTw8nLMKAADgy3CmXZm//PKLeTxgwACZOHGiZMuWTXr37i39+vVLT10AAAACXprHnGkIczRq1Mhc9Hzz5s1m3FnlypUD/oQCAAD4bZ0zFRkZaW4AAADwYbdmTEyMLFiwwGubztosWbKkWfOsS5cuEh8fnwFVAgAACFypDmfDhw+X7du3u59v27ZNOnfubLo2deyZTgiIjo6+WfUEAAAICKkOZ1u2bJGGDRu6n8+cOVNq164t//nPf6RPnz4yfvx498xNAAAA3ORw9s8//0jBggXdz1etWiXNmjVzP7/nnnvk0KFDfA8AAAC+CGcazJz1zfRi5zpDs06dOu79Z86ckSxZsqSnLgAAAAEv1eHskUceMWPLfvzxR4mKipLs2bObSzc5tm7dKnfeeWfAn1AAAACfLKXx1ltvSevWraV+/fqSM2dOmT59uoSEhLj3T5kyRRo3bpyuygAAAAS6VIeziIgIc+3M06dPm3AWHBzstX/OnDlmOwAAAHy4CG1YWFiy2/PmzZuOagAAAOCGrq0JAACAm4dwBgAAYBHCGQAAgEUIZwAAALfahIB58+al+oCPPfZYeuoDAAAQ0FIVzlq1apWqgwUFBcnVq1fTWycAAICAlapwlpCQcPNrAgAAAMacAQAA3NKL0Kpz587JqlWr5ODBg+Yi6J569OiRUXUDAAAIOGkOZz///LO5CPr58+dNSNMrA5w4ccJcCL1AgQKEMwAAAF8updG7d2959NFH5Z9//pHQ0FBZu3atHDhwQGrUqCH//ve/01MXAACAgJfmcLZlyxbp27evZMqUyVz8PD4+XooVKyajR4+WgQMHBvwJBQAA8Gk4y5IliwlmSrsxddyZc0H0Q4cOpasyAAAAgS7NY86qVasmGzZskDJlykj9+vVl8ODBZszZZ599JhUrVrw5tQQAAAgQaW45e+edd6Rw4cLm8dtvvy158uSRV155RY4fPy4fffTRzagjAABAwEhzy1nNmjXdj7Vbc/HixRldJwAAgICV5pazhx56SE6dOpVke1xcnNkHAAAAH7acrVy5MsnCs+rixYvy448/pqMqQMoiByzkFAWQ/SOb+7sKAGB3ONu6dav78W+//SZHjx51P9eLnWv3ZtGiRTO+hgAAAAEk1eGsatWqEhQUZG7JdV/qgrQTJkzI6PoBAAAElFSHs3379onL5ZJSpUrJ+vXrJX/+/O59ISEhZnKALkoLAAAAH4SzEiVKmPuEhIR0vB0AAAAydEKA2rt3r4wdO1Z27NhhnleoUEF69uwpd955540cDgAAADe6lMaSJUtMGNOuzcqVK5vbunXr5O6775alS5em9XAAAABIT8vZgAEDpHfv3jJy5Mgk29944w15+OGH03pIAAAA3GjLmXZldu7cOcn2Tp06mSU2AAAA4MNwprM0t2zZkmS7btMZmwAAAPBBt+bw4cPl9ddfl5deekm6dOkif/zxh9x7771m3+rVq2XUqFHSp0+fdFQFAAAAqQ5nw4YNk65du8qbb74puXLlknfffVeioqLMviJFisjQoUOlR48enFEAAABfhDNdgFbpFQJ0QoDezpw5Y7ZpWAMAAICPZ2tqMPNEKAMAAPBjOCtbtmySgJbYyZMn01snAACAgJWmcKbjzsLCwm5ebQAAAAJcmpbSaNeunXTo0CHFW1pER0fLPffcY7pHdRmOVq1aya5du7zKXLx4Ubp16yb58uWTnDlzSps2beTYsWNeZQ4ePCjNmzeX7Nmzm+P069dPrly54lVm5cqVUr16dcmaNauULl1apk2blqQ+EydOlMjISMmWLZvUrl3bXAXBX3UBAACBKdXh7HrdmTdi1apVJuysXbvWXPrp8uXL0rhxYzl37py7jE48mD9/vsyZM8eUP3LkiLRu3dq9/+rVqyYMXbp0SdasWSPTp083YWfw4MHuMvv27TNlGjRoYNZj69Wrl7z44ovmUlSOWbNmmaVAhgwZIps3b5YqVapIkyZNJDY21ud1AQAAgSvI5UzDvI5MmTLJ0aNHb+pCs8ePHzfH1+DzwAMPyOnTp82itzNmzJAnnnjClNm5c6eUL19eYmJipE6dOrJo0SJp0aKFCUoFCxY0ZSZPnmwuJaXHCwkJMY8XLlwov/76q1cr4KlTp2Tx4sXmubaUaSveBx98YJ4nJCRIsWLF5LXXXjOXpvJlXVISFxdnupa1Prlz55ZAEjlgob+rAB/aP7I55zuA8PcdWALx7zsuDb/fqW4507Bys68AoBVWefPmNfebNm0yrWmNGjVylylXrpwUL17cBCKl95UqVXKHIaUtXnoStm/f7i7jeQynjHMMbenS9/Iso2FUnztlfFWXxOLj483rPW8AAOD2lebLN90sGv60i+++++6TihUrmm3aUqetTeHh4V5lNfzoPqeMZxhy9jv7UiqjQefChQty4sQJ0yWZXBnPY/iiLsmNy9Ok7dy0NQ8AANy+rAlnOvZMu/pmzpzp76pYRa/CoC2Kzu3QoUP+rhIAALjdw1n37t1lwYIFsmLFCrnjjjvc2wsVKmS6HHU8liedIan7nDKJZ0w6z69XRvt8Q0NDJSIiQoKDg5Mt43kMX9QlMZ3Rqfs8bwAA4Pbl13CmcxE0mM2dO1eWL18uJUuW9Npfo0YNyZIliyxbtsy9TZfa0OUq6tata57r/bZt27xmVerMTw0xFSpUcJfxPIZTxjmGdlfqe3mW0W5Wfe6U8VVdAABAYEvTIrQ3oytTZz9+8803Zq0zZ1yWjq3SViS979y5s1niQicJaMjR2ZMaZHR2pNKlNzT4PPfcczJ69GhzjEGDBplja6uT0gu26yzM/v37S6dOnUwQnD17tpk16dD30HXaatasKbVq1ZKxY8eaJT06duzorpOv6gIAAAKXX8PZpEmTzP2DDz7otX3q1KnywgsvmMfvv/++mTmpC77qzEWd2fjhhx+6y2p3pHaJvvLKKyYo5ciRw4Ss4cOHu8toi5yGH12nbNy4cabr9JNPPjHHcrRt29Ysd6Frkmmoqlq1qlnawnPwvq/qAgAAAleq1zmDHVjnDIEiENdBCmSscxZYAvHvO+5mrHMGAACAm49wBgAAYBHCGQAAgEUIZwAAABYhnAEAAFiEcAYAAGARwhkAAIBFCGcAAAAWIZwBAABYhHAGAABgEcIZAACARQhnAAAAFiGcAQAAWIRwBgAAYBHCGQAAgEUIZwAAABYhnAEAAFiEcAYAAGARwhkAAIBFCGcAAAAWIZwBAABYhHAGAABgEcIZAACARQhnAAAAFiGcAQAAWIRwBgAAYBHCGQAAgEUIZwAAABYhnAEAAFiEcAYAAGARwhkAAIBFCGcAAAAWIZwBAABYhHAGAABgEcIZAACARQhnAAAAFiGcAQAAWIRwBgAAYBHCGQAAgEUIZwAAABYhnAEAAFiEcAYAAGARwhkAAIBFCGcAAAAWIZwBAABYhHAGAABgEcIZAACARQhnAAAAFiGcAQAAWIRwBgAAYBHCGQAAgEUIZwAAABYhnAEAAFiEcAYAAGARwhkAAIBFCGcAAAAWIZwBAABYhHAGAABgEcIZAACARQhnAAAAFiGcAQAAWIRwBgAAYBG/hrMffvhBHn30USlSpIgEBQXJ119/7bXf5XLJ4MGDpXDhwhIaGiqNGjWS3bt3e5U5efKktG/fXnLnzi3h4eHSuXNnOXv2rFeZrVu3yv333y/ZsmWTYsWKyejRo5PUZc6cOVKuXDlTplKlSvLtt9/6rS4AACBw+TWcnTt3TqpUqSITJ05Mdr8Gl/Hjx8vkyZNl3bp1kiNHDmnSpIlcvHjRXUbD0Pbt22Xp0qWyYMECE/i6dOni3h8XFyeNGzeWEiVKyKZNm2TMmDEydOhQ+fjjj91l1qxZI08//bQJUz///LO0atXK3H799Vef1wUAAAS2IJc2CVlAW87mzp1rQpHSammLWt++feX11183206fPi0FCxaUadOmSbt27WTHjh1SoUIF2bBhg9SsWdOUWbx4sTzyyCPy559/mtdPmjRJ/vWvf8nRo0clJCTElBkwYIBppdu5c6d53rZtWxMUNVA56tSpI1WrVjVhzJd1SSw+Pt7cPAOetrjp+2sLXSCJHLDQ31WAD+0f2ZzzHUD4+w4sgfj3HRcXJ2FhYan6/bZ2zNm+fftMiNHuQ4d+qNq1a0tMTIx5rvfafeiEIaXlM2XKZFq3nDIPPPCAOwwpbfHatWuX/PPPP+4ynu/jlHHex5d1SSw6Otq8l3PTYAYAAG5f1oYzDUNKW6c86XNnn94XKFDAa3/mzJklb968XmWSO4bne1yrjOd+X9UlsaioKJOynduhQ4euccYAAMDtILO/K4CUZc2a1dwAAEBgsLblrFChQub+2LFjXtv1ubNP72NjY732X7lyxcya9CyT3DE83+NaZTz3+6ouAAAgsFkbzkqWLGkCy7Jly7wG0+n4rbp165rnen/q1Ckz89GxfPlySUhIMOPBnDI6a/Ly5cvuMjqb8q677pI8efK4y3i+j1PGeR9f1gUAAAQ2v4YzXQNsy5Yt5uYMvNfHBw8eNLM3e/XqJSNGjJB58+bJtm3b5PnnnzezHp0ZneXLl5emTZvKSy+9JOvXr5fVq1dL9+7dzexJLaeeeeYZMwBfl8nQZS5mzZol48aNkz59+rjr0bNnTzOz8t133zWzJnV5i40bN5pjKV/WBQAABDa/jjnTANSgQQP3cyekdOjQwSxR0b9/f7PEha4Vpq1S9erVMyFKF3B1fPHFFyYENWzY0MyMbNOmjVmPzKEzHL/77jvp1q2b1KhRQyIiIsxisp7rj917770yY8YMGTRokAwcOFDKlCljlreoWLGiu4yv6gIAAAKbNeucIePXSbndsA5SYAnEdZACGX/fgSUQ/77jbod1zgAAAAIR4QwAAMAihDMAAACLEM4AAAAsQjgDAACwCOEMAADAIoQzAAAAixDOAAAALEI4AwAAsAjhDAAAwCKEMwAAAIsQzgAAACxCOAMAALAI4QwAAMAihDMAAACLEM4AAAAsQjgDAACwCOEMAADAIoQzAAAAixDOAAAALEI4AwAAsAjhDAAAwCKEMwAAAIsQzgAAACxCOAMAALAI4QwAAMAihDMAAACLEM4AAAAsQjgDAACwCOEMAADAIoQzAAAAixDOAAAALEI4AwAAsAjhDAAAwCKEMwAAAIsQzgAAACxCOAMAALAI4QwAAMAihDMAAACLEM4AAAAsQjgDAACwCOEMAADAIoQzAAAAixDOAAAALEI4AwAAsAjhDAAAwCKEMwAAAIsQzgAAACxCOAMAALAI4QwAAMAihDMAAACLEM4AAAAsQjgDAACwCOEMAADAIoQzAAAAixDOAAAALEI4AwAAsAjhDAAAwCKEMwAAAIsQzgAAACxCOAMAALAI4cxPJk6cKJGRkZItWzapXbu2rF+/3l9VAQAAFiGc+cGsWbOkT58+MmTIENm8ebNUqVJFmjRpIrGxsf6oDgAAsAjhzA/ee+89eemll6Rjx45SoUIFmTx5smTPnl2mTJnij+oAAACLZPZ3BQLNpUuXZNOmTRIVFeXelilTJmnUqJHExMQkKR8fH29ujtOnT5v7uLg4CTQJ8ef9XQX4UCD+Gw9k/H0HlkD8+477/z+zy+W6blnCmY+dOHFCrl69KgULFvTars937tyZpHx0dLQMGzYsyfZixYrd1HoC/hY21t81AHCzBPLf95kzZyQsLCzFMoQzy2kLm45PcyQkJMjJkyclX758EhQU5Ne6wTf/paVB/NChQ5I7d25OOXAb4e87sLhcLhPMihQpct2yhDMfi4iIkODgYDl27JjXdn1eqFChJOWzZs1qbp7Cw8Nvej1hFw1mhDPg9sTfd+AIu06LmYMJAT4WEhIiNWrUkGXLlnm1hunzunXr+ro6AADAMrSc+YF2U3bo0EFq1qwptWrVkrFjx8q5c+fM7E0AABDYCGd+0LZtWzl+/LgMHjxYjh49KlWrVpXFixcnmSQAaJe2roeXuGsbwK2Pv29cS5ArNXM6AQAA4BOMOQMAALAI4QwAAMAihDMAAACLEM4AAAAsQjgDAACwCOEMAADAIoQzAAAAi7AILWDRRZBTi+tsAre2DRs2yIoVKyQ2NtZcws/Te++957d6wQ6EM8ASekH7oKCgFMvomtFa5urVqz6rF4CM9c4778igQYPkrrvuMleG8fy7v97/ByAwcIUAwBKrVq1Kddn69evf1LoAuHk0kI0aNUpeeOEFTjOSRcsZYAkCFxAYMmXKJPfdd5+/qwGL0XIGWOz8+fNy8OBBuXTpktf2ypUr+61OANJn9OjRcuTIERk7diynEskinAEWOn78uHTs2FEWLVqU7H7GnAG3Lp0A0Lx5c/n999+lQoUKkiVLFq/9X331ld/qBjuwlAZgoV69esmpU6dk3bp1EhoaKosXL5bp06dLmTJlZN68ef6uHoB06NGjh5mpWbZsWcmXL5+EhYV53QBazgALFS5cWL755hupVauWWTZj48aN5v/INZhpl8hPP/3k7yoCuEG5cuWSmTNnmtYzIDm0nAEWOnfunBQoUMA8zpMnj+nmVJUqVZLNmzf7uXYA0iNv3rxy5513chJxTYQzwEK6/tGuXbvM4ypVqshHH30khw8flsmTJ5tWNQC3rqFDh8qQIUPMhB8gOXRrAhb6/PPP5cqVK2YdpE2bNknTpk3l5MmTEhISItOmTZO2bdv6u4oAblC1atVk7969ZlHpyMjIJBMCaB0H65wBFnr22Wfdj2vUqCEHDhyQnTt3SvHixSUiIsKvdQOQPq1ateIUIkW0nAEAAFiEljPAQtrd8eWXX17zwsisgwQAty/CGWDpOmc6CaBBgwZJLowM4Na/fFNKf9MsMg3CGWChzz77zLSOPfLII/6uCoAMNnfuXK/nly9flp9//tksND1s2DDONxhzBtioZMmS5tJN5cqV83dVAPjIjBkzZNasWWYBagQ2JgQAFtL/gtZLNk2ZMsVcvgnA7e+PP/6QypUry9mzZ/1dFfgZ3ZqAhZ566in53//+Z64SwDpIwO3vwoULMn78eClatKi/qwILEM4AC3Xo0MEsPqvrnTEhALi96CXZPCcE6OzsM2fOSPbs2c0C1ADdmoCFcuTIIUuWLJF69er5uyoAMphe5cMznOnszfz580vt2rVNcANoOQMsVKxYMcmdO7e/qwHgJtDLsgEpoeUMsNDChQtlwoQJ5kLnOuYMwK1t69atUrFiRdNKpo9TopMCENgIZ4CFtGvj/Pnz5uLnOg4l8YWR9SLoAG4dGsqOHj1qJvk4i9DqWLPEdDuL0IJuTcBCY8eO9XcVAGSgffv2mXFlzmMgJbScAZbR1cJffvllefPNN81itACAwEI4AywUFhYmW7ZsIZwBt6kjR47ITz/9JLGxsZKQkOC1r0ePHn6rF+xAOAMsXeesatWq0rt3b39XBcBNWEpDW8dDQkIkX758Xstq6GO9UgACG+EMsNCIESPk3XfflYYNG0qNGjXMumee+C9r4NZeKqdr164SFRVlJgcAiRHOAAulNNaM/7IGbm3aWrZ+/Xq58847/V0VWIpwBgCAD/Xv31/y5s0rAwYM4LwjWYQzwHLOWkie41IA3Lp0HbMWLVqYi51XqlQpyTqG7733nt/qBjuwzhlgqU8//VTGjBkju3fvNs/Lli0r/fr1k+eee87fVQOQDtHR0ebauXfddZd5nnhCAEA4Ayyk/+Ws65x1795d7rvvPrNNp93rIOITJ04wixO4helknylTpnCNTVwT3ZqApRMChg0bJs8//7zX9unTp8vQoUNZYRy4hRUqVEh+/PFHKVOmjL+rAksxhxew0F9//SX33ntvku26TfcBuHX17NlTJkyY4O9qwGJ0awIWKl26tMyePVsGDhzotX3WrFn81zZwi9NlNJYvXy4LFiyQu+++O8mEgK+++spvdYMdCGeAhbRLs23btvLDDz+4x5ytXr1ali1bZkIbgFtXeHi4tG7d2t/VgMUYcwZYatOmTWZiwM6dO83z8uXLS9++faVatWr+rhoA4CYinAEA4GNXrlyRlStXyt69e+WZZ56RXLlymYuh586dW3LmzMn3EeAIZ4BF9Dp711vnSPfr/7EDuDUdOHBAmjZtKgcPHpT4+Hj5/fffpVSpUmaigD6fPHmyv6sIP2PMGWCRuXPnXnNfTEyMjB8/XhISEnxaJwAZS0NYzZo15ZdffjHX2XQ8/vjj8tJLL3G6QTgDbNKyZcsk23bt2mWuwTd//nxp3769DB8+3C91A5AxdI2zNWvWSEhIiNf2yMhIOXz4MKcZrHMG2ErHn+h/Reu197Qbc8uWLWYR2hIlSvi7agDSQVu/9fqaif35559m7BnAIrSAZU6fPi1vvPGGWets+/btZvkMbTWrWLGiv6sGIAM0btxYxo4d6zWO9OzZszJkyBB55JFHOMdgQgBgk9GjR8uoUaPM5V3eeeedZLs5AdzaDh06ZCYEuFwu2b17txl/pvcRERFmbcMCBQr4u4rwM2ZrApbN1gwNDZVGjRpJcHDwNcuxgjhwa9OhCnrFD50UoK1m1atXN2NK9e8fIJwBFnnhhReuu5SGmjp1qk/qAyBjXb58WcqVK2cu3aQLSwPJYSkNwCLTpk3zdxUA3ER6Hc2LFy9yjpEiJgQAAOBD3bp1M2NLWUwa10K3JgAAPqSLzeosbL1Mky6VkyNHDq/9jCkF3ZoAAPhQeHi4tGnThnOOayKcAQDgo8Vnx4wZY66leenSJXnooYdk6NChzNBEEow5AwDAB95++20ZOHCg6c4sWrSouVaujj8DEmPMGQAAPlCmTBl5/fXX5eWXXzbPv//+e2nevLlcuHDBrHEIOAhnAAD4QNasWWXPnj1SrFgx97Zs2bKZbXfccQffAdyI6gAA+IAunaFhLPG6Z7owLeCJCQEAAPiAXktTrwKiLWgOXZC2a9euXstpsJQGCGcAAPhAhw4dkmx79tlnOfdIgjFnAAAAFmHMGQAAgEUIZwAAABYhnAEAAFiEcAYAAGARwhkA+NCDDz4ovXr18vk512s4Vq1a1cq6AfBGOAMQMHSNqaCgILOuVGJ6jUPdp2UCla6v9dZbb/m7GkDAI5wBCCh66ZyZM2ea6xl6LgQ6Y8YMKV68uNyKrl69KgkJCek+Tt68eSVXrlwZUicAN45wBiCgVK9e3QQ0z1XY9bEGs2rVqrm3adiJjo6WkiVLSmhoqFSpUkW+/PJL9/6VK1ealrYlS5aY12mZhx56SGJjY2XRokVSvnx5yZ07tzzzzDNy/vz5JJfx6d69u4SFhUlERIS8+eabZvV4R3x8vLlAdtGiRc3K8bVr1zbv55g2bZqEh4fLvHnzpEKFCmbF+YMHD5oytWrVMq/R/ffdd58cOHDA670/++wziYyMNO/drl07OXPmzDW7NbWctqQ9/fTT5phan4kTJ2bI9wDg2ghnAAJOp06dZOrUqe7nU6ZMkY4dO3qV0WD26aefyuTJk2X79u3Su3dvs5r7qlWrkozl+uCDD2TNmjVy6NAheeqpp2Ts2LGmJW7hwoXy3XffyYQJE7xeM336dMmcObOsX79exo0bJ++995588skn7v0a3GJiYkwL39atW+XJJ5+Upk2byu7du91lNPCNGjXKvE7rp61erVq1kvr165vX6Ou7dOliAqRj79698vXXX8uCBQvMTT/LyJEjUzxXY8aMMcH0559/lgEDBkjPnj1l6dKlN3DWAaSaCwACRIcOHVwtW7Z0xcbGurJmzerav3+/uWXLls11/Phxs0/LXLx40ZU9e3bXmjVrvF7fuXNn19NPP20er1ixQpu6XN9//717f3R0tNm2d+9e97aXX37Z1aRJE/fz+vXru8qXL+9KSEhwb3vjjTfMNnXgwAFXcHCw6/Dhw17v3bBhQ1dUVJR5PHXqVPM+W7Zsce//+++/zbaVK1cm+9mHDBliPlNcXJx7W79+/Vy1a9f2qlvPnj3dz0uUKOFq2rSp13Hatm3ratasWYrnGUD6cG1NAAEnf/780rx5c9M9qN2J+li7Fx179uwxLVMPP/yw1+suXbrk1fWpKleu7H5csGBByZ49u5QqVcprm7aQeapTp45Xi1bdunXl3XffNWPHtm3bZu7Lli3r9Rrt6syXL5/7eUhIiNd7a8uZTmZo0qSJqXejRo1MK17hwoW9uik9x5TpPu2GTYnWLfFzbRkEcPMQzgAEbNemdh+qxOOozp49a+61W1LHWXnS8V2esmTJ4n6sgcvzubMtLYP19b2Dg4Nl06ZN5t5Tzpw53Y91jJtnwFPaVdujRw9ZvHixzJo1SwYNGmS6IDUMJq7rjdQNgG8QzgAEJB3DpS1hGlC0tcmT5yB7HcOV0datW+f1fO3atVKmTBkTxrRlTlvOtEXr/vvvT/Ox9fV6i4qKMq1cOvbNCWc3QuuW+LlOdgBw8xDOAAQkDUI7duxwP/akXX86W1InAWjLUr169eT06dOyevVqMwOzQ4cO6XpvDX19+vSRl19+WTZv3mwmDGi3ptLuzPbt28vzzz9vtmnQOn78uCxbtsx0Y2oXbHL27dsnH3/8sTz22GNSpEgR2bVrl5lAoMdJD/3Mo0ePNpMNtBVuzpw5pkURwM1DOAMQsDRoXYsuIaFj03TW5h9//GGWptBlOAYOHJju99XApOus6bIXGgx1BqTOrPTsnhwxYoT07dtXDh8+bMbDaetXixYtrnlMHeu2c+dOMxP077//NuPJdGFdDYDpoXXYuHGjDBs2zJwvnVmauKURQMYK0lkBGXxMAMBtQCcQ6LpnXNIJ8C3WOQMAALAI4QwAAMAidGsCAABYhJYzAAAAixDOAAAALEI4AwAAsAjhDAAAwCKEMwAAAIsQzgAAACxCOAMAALAI4QwAAEDs8f8BrsjwYmQTh1gAAAAASUVORK5CYII=",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "total_sales.plot(kind=\"bar\")\n",
+    "plt.title(\"Total Sales by Membership\")\n",
+    "plt.xlabel(\"Membership\")\n",
+    "plt.ylabel(\"Total Sales\")\n",
+    "plt.ticklabel_format(style='plain', axis='y')\n",
+    "plt.show()\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "baef3d84",
+   "metadata": {},
+   "source": [
+    "# Average sales"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 169,
+   "id": "34ae843d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "membership\n",
+       "Normal    457.49\n",
+       "Premium   450.90\n",
+       "Name: sales, dtype: float64"
+      ]
+     },
+     "execution_count": 169,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "avg_sales = df.groupby(\"membership\")[\"sales\"].mean()\n",
+    "pd.options.display.float_format = '{:,.2f}'.format\n",
+    "df = df[df[\"membership\"] != \"Not Logged In\"]\n",
+    "avg_sales"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 177,
+   "id": "bea881f9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAjsAAAH2CAYAAACWSE2sAAAAOnRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjEwLjcsIGh0dHBzOi8vbWF0cGxvdGxpYi5vcmcvTLEjVAAAAAlwSFlzAAAPYQAAD2EBqD+naQAAOhNJREFUeJzt3Qd4U/X+x/FvKVB2oSBTtpUhGwQRrsiQqYhwBRShIn9ELshSBBTZslSmKA5kqiAKKqissmRDmSIgoAzZKKvskf/z/d2bPElooYum+eX9ep6Q5JyT5JeTlPPJb50gh8PhEAAAAEul8nUBAAAA7iXCDgAAsBphBwAAWI2wAwAArEbYAQAAViPsAAAAqxF2AACA1Qg7AADAaoQdAABgNcIOgGSxfPlyCQoKMtfJZcCAAeY1T58+LYFO90Pnzp0lpXjxxRclU6ZMcS67fpZAQhF2ENA+/PBD8x9plSpVfF2UFOfatWsyduxYKV++vGTJkkWyZs0qDz30kLz88suye/duXxcvRXn88cfN9yg8PDzG9YsXLzbr9fLNN98ke/mAQJfa1wUAfOmLL76QQoUKyYYNG2Tfvn3ywAMP8IH8T7NmzeTnn3+W5557Ttq3by/Xr183IWf+/Pny6KOPSvHixdlXbtKlS2e+Q/pdqly58m3fM11/5coV9lkCXL58WVKn5nCFhKNmBwHrzz//lDVr1sioUaPkvvvuMwek5Hbr1q0UeQDcuHGjCTWDBg2S6dOny3/+8x/p2rWrfPTRR3LgwAF56qmnfF3EFKdo0aJSrFgx+eqrrzyW6+c7d+5cadSokdhO36t+p5OaBkXCDhKDsIOApeEmW7Zs5iD073//2yPsaC1GWFiYtG3b9rbHnT9/3vzn+/rrr7uWXb16Vfr3729qhkJCQiR//vzyxhtvmOUx9ZvQ19ImId12wYIFZt17771nakyyZ88u6dOnl4oVK8bY5KG/crt06SI5cuSQzJkzS+PGjeXIkSMx9mvQ5S+99JLkypXLvJa+5ueff37XfbN//35zXa1atdvWBQcHmzI6HTx40IQhPdBruXXds88+a0JRXKxfv17q168voaGhkiFDBqlRo4asXr3aY5sLFy5It27dTC2cvo+cOXPKE088IZs3b47Ta2ifnebNm5vmOC2fBjf3kKmvWbZs2Rgfq++rXr16cXodrQWbNWuWxwF/3rx5cunSJfP6MYnLZ+Ts7/T111/LwIEDJV++fOaz1+/tuXPnzPdM94/uF+0Ho99b7++ek3739D3pd1i/YytXrkxUmWbOnCl9+/Y1ZdLPT/8+9O9Hy6nNevo6us+rV69umvNieq0mTZqYcuuPDv27unnzpsc23t9tZ18srWm80+cKOFEviICl/+k3bdpU0qZNaw5SWmuhNRoPP/ywpEmTRp555hmZM2eOfPzxx2Ybp++++84cSFq2bGnu64FNA8eqVatMf5YSJUrIjh07ZPTo0fL777+b7d0tXbrUHLQ09Ghg0QO40v4x+jytWrUy/WX0IKKhQWtY3GsFtGOnPr5169byyCOPyIoVK2KsNThx4oRZ7wxYeiDRZql27dqZA5IeHGNTsGBB1z7SwHOnX9W6z7SGTPfH/fffb0KO7kvtx/Lbb7+ZA2BsdF80aNDAHHQ1LKZKlUomT54stWrVkl9++cXVHPTKK6+Y4Kfvo2TJkvL333+b/b1r1y6pUKGC3I0eEHU/Dxs2TNatWyfjxo2TM2fOyLRp08x63ZfaVPfrr79KqVKlPN6bfoZ6MI+L559/3hyINQjoe1Bffvml1K5d2wSRxH5GWn4NlL179zZNZuPHjzffVd1v+n70tfX9TZkyRQoXLiz9+vXzeLx+VzSMaVjWEKN91jRoatOb833Ht0yDBw82fx8aUvTvQm9rObSs//d//2c+Q33cpk2bTDjVkOqkoUaDpPaZ07C/ZMkSef/9900tWceOHRP9uQIuDiAAbdq0yaFf/8WLF5v7t27dctx///2Orl27urZZuHCh2WbevHkej23YsKGjSJEirvvTp093pEqVyvHLL794bDdx4kTz+NWrV7uW6X3ddufOnbeV6dKlSx73r1275ihVqpSjVq1armVRUVHmObp16+ax7YsvvmiW9+/f37WsXbt2jjx58jhOnz7tsW3Lli0doaGht72eO90fNWrUMM+ZK1cux3PPPeeYMGGC4+DBg3ctt1q7dq157LRp01zLli1bZpbptfM1wsPDHfXq1TO33Z+vcOHCjieeeMK1TMvbqVMnR3zp/tDXbNy4scfy//znP2b5tm3bzP2zZ8860qVL5+jVq5fHdl26dHFkzJjRER0dfcfX0X310EMPmduVKlUy+16dOXPGkTZtWsfUqVNd73/27Nnx/oycj9Xvg34vnPRzCQoKcjRo0MDj8VWrVnUULFjQY5k+Xi/63XfSz1Pf9zPPPJPgMunfgvd3oGzZso5GjRrdcZ9FRESYxw8aNMhjefny5R0VK1a8rezu3+24fq6AE81YCEhaY6FV9DVr1jT39VdsixYtTG2Kswpdf5lrzYv+EnbSX41aFa/bOs2ePdvU5miHXW0ucV6cv+yXLVvm8draZKK1E970F7v762jzxL/+9S+Pphpnk5c2G7l79dVXPe7r8eHbb781fWv0tnu59Je0PvedmoB0fyxcuFCGDBlimvq0H0qnTp1MjY++97Nnz8ZYbm2+0FoXbc7T0Vt3eo2tW7fK3r17TW2IPsZZvosXL5qaEG1ecTYH6XNpc9fRo0clIbTsMe2vn376yVxrE9rTTz9t3ud/j63/rXXQz16bWDJmzBjn19L3ozWCWjuntVHa7Ke1hN4S8hm1adPG1OQ4aY2IPlabnNzp8sOHD8uNGzc8lletWtXUojkVKFDAvG/9rPX9JqRMERERHt8B5+e1c+dO8/nejdbaudPv/B9//CFJ8bkCToQdBBz9T11DjQYd7aSszQF60QOEVuFHRkaa7bTpRkckff/9967+D3oQ0wO6e9jR/9D1P3at7ne/PPjgg2b9yZMnPV5fmxdios1V2nygfRy0v5A+hzYH6QHGvX+MNll4P4f3KLJTp06ZQPLJJ5/cVi5nPyTvcnnTZo633nrLNBVpyNAgoOVzNsG59yHS5hLtp6SP0YCor6Ov7152b84DoR4svcv42WefmX3ufPzIkSNNE5O+hjaLaDNJXA+IyntIuDaT6H5071ekQeLQoUOm+Uxpk4p+H7SJKz60OU/LrU0/GqqffPJJ07/GW0I+Iw0n7jSkKd0v3ss1KHrv/5iGxuv3VPsUaXkSUqaYvs/asV2fR5+7dOnS0rNnT9m+fftt2+l3XZ/bnYZrDftJ9bkCij47CDjaT+TYsWMm8OjFmx6g6tat6zpwaZ8dPXDpL3w90GsNjntnVj2o6H/oOqorJt4HIu9fwUoPsNpf57HHHjP9KPLkyWN+wWv/Fe3zEV/OGpEXXnjBhImYlClTJs7Pp+XRfaHhTzur6n7QfiEaCPXXtJZT+3JozYEeaLVmSLe/08gc57p3331XypUrF+M2zknntG+G/uLXUU2LFi0yjxkxYoQJn9rnJ760fN605kJr+2bMmGE+B73OnTu31KlTJ17PrftK+ytp3xPtaK01JUn1GWktUUxiW+6spYqrhJQppu+z7j/t5K4/FPTz0vCqfdgmTpxo+vHcrdwJFdPnCijCDgKOhhntLDphwoTb1unBUw+o+p+y/ieu/2nrwUubM3Q0iQYlre3w/jW5bds20/SS0P9s9YCov3K1OUFrR5w0RLjTZiQ9IGmNlPuvWq2Zcqe/lrU2QWux4nuwvhMNYHqw01oZbdrQMKBNNXpg1IO7k46IcW/qionuN6UjaeJSRv0ctPlOL1q7oB2T33nnnTiFHS2vew2E7i/dj87O4c4DrzZBaYjTIKUdy7XTckIOyPo8elDX5pyGDRvGuM29+ozuJKZmJe2ArZ3InTUsSVUm52hGvURHR5u/Ja2Rcw87iRWXzxVQNGMhoGiTiwYabVrQYbveF22e0WHOP/zwg9leq8R1uQ4f1vlmtA+EexOWs9ZBh89++umnMb6e9kG5Gz2galByH3KrVfHeI7mcQ6C19sedjsrxfj6thdEQpc0/3rS54m4HEW3S8aYBZu3ataapwXlw1NfyrkHQ8ngPH/amfUc08OgoHD0YxlZGfR7v5hgNq3nz5o11eLU372Dr3F/eQUmbrLQJpUOHDqZMWsOREPqd0dFl+jm5j+RLys8oIfSzc+9zo/16tPZFazK1PElVJu2D5V1Dp02tcf284iqunytAzQ4CioYYDTPaZBQT7ZPinGDQGWr0Wv8T1YOXNldpZ2TvA6Q262hHS+2MrEO19QCtc4Docq2tqVSp0h3LpUPHtRlMhwFrrYDWXOh/5HqAcO/roAFBD0ZjxowxBxTn0HP9da7ca5aGDx9uyqN9kbSGQjtF//PPP+Zgp/1R9HZstKZKy6EHDW0+0l/pGuimTp1q+u/o6ztrPDQ4ahDU5it9DT2g6vO7z8UTEw2S2ryhr6FNY1oDoHO16OtoubXGR0Omfl46pF0DhDYf6oFTn1+HhbvXJt2J1oTpZ677V8unTVT6/rzn1tFTY+gQbGen87gMa4+J7ou4nMspMZ9RQuh708DsPvRc6Zw4SVkmfYw25en3Vb87OuzcOXVAUorr5wow9BwB5amnnjJDbS9evBjrNjqMO02aNK6htzosOn/+/GZI65AhQ2J8jA4HHjFihBl+HBIS4siWLZsZPjtw4EDHuXPnXNvpc8Q2hHrSpElmKLY+vnjx4o7Jkye7hti607Lrc4SFhTkyZcrkaNKkiWPPnj1mu+HDh3tse+LECbOtll/fU+7cuR21a9d2fPLJJ3fcT/o4fS4dUq3DkFOnTm3ekw6D/+abbzy21eHVbdu2deTIkcOUR4eS79692wx91uHFsQ09d9qyZYujadOmjuzZs5v3ro9r3ry5IzIy0qy/evWqo2fPnmY4c+bMmc1QcL394YcfOu7Guf9+++03x7///W/zeH0fnTt3dly+fDnGx4wcOdI8ZujQoY64ch96HpuYhp7H9TOK7bH6HdHlGzdujPF9nzp16rbv3owZM1zfMx3m7f15JLZMSv9OKleu7MiaNasjffr05vv8zjvveAyb1++GfpbeYvrOxzb0PD6fKwJbkP5D5gP8mw7j1loJ/WWrkxIi4XRyx+7du5tmRO/RT0gZtNZMa6O0WU1H/wF3Q58dwM9oPyBv2qykzULaCRQJp7/9Jk2aZOZCIugA9qDPDuBndM6ZqKgoM0+QDv3WYfF60VNVeA9zR9xoJ3Ltz6V9VfRUH9ppF4A9CDuAn9GTheosznpOIh0xpDUQWq3vPSQecafNIdqxVYeKv/nmm7F2YAfgn+izAwAArEafHQAAYDWasf43RbrOHaIzhzLdOAAA/jOoQOfi0klGdZBGbAg7Iibo0LETAAD/pLOB6+SjsSHs/O9cMM6dpbO2AgCAlO/8+fOmssJ5HI8NYcdtin0NOoQdAAD8y926oNBBGQAAWI2wAwAArEbYAQAAViPsAAAAqxF2AACA1Qg7AADAaoQdAABgNcIOAACwGmEHAABYjbADAACsRtgBAABWI+wAAACrEXYAAIDVCDsAAMBqhB0AAGC11L4uAHyrUO8f+QgCyIHhjXxdBABIdtTsAAAAqxF2AACA1Qg7AADAaoQdAABgNTooA4ClGIAQWBiAEDtqdgAAgNUIOwAAwGqEHQAAYDXCDgAAsBphBwAAWI2wAwAArEbYAQAAViPsAAAAqxF2AACA1Qg7AADAaoQdAABgNcIOAACwGmEHAABYjbADAACsRtgBAABWI+wAAACrEXYAAIDVCDsAAMBqhB0AAGA1wg4AALAaYQcAAFiNsAMAAKxG2AEAAFYj7AAAAKsRdgAAgNUIOwAAwGqEHQAAYDXCDgAAsBphBwAAWI2wAwAArEbYAQAAViPsAAAAqxF2AACA1Qg7AADAaoQdAABgtRQTdoYPHy5BQUHSrVs317IrV65Ip06dJHv27JIpUyZp1qyZnDhxwuNxhw4dkkaNGkmGDBkkZ86c0rNnT7lx44YP3gEAAEiJUkTY2bhxo3z88cdSpkwZj+Xdu3eXefPmyezZs2XFihVy9OhRadq0qWv9zZs3TdC5du2arFmzRqZOnSpTpkyRfv36+eBdAACAlMjnYSc6OlpatWoln376qWTLls21/Ny5czJp0iQZNWqU1KpVSypWrCiTJ082oWbdunVmm0WLFslvv/0mM2bMkHLlykmDBg1k8ODBMmHCBBOAYnP16lU5f/68xwUAANjJ52FHm6m0dqZOnToey6OiouT69esey4sXLy4FChSQtWvXmvt6Xbp0acmVK5drm3r16pnwsnPnzlhfc9iwYRIaGuq65M+f/568NwAAEOBhZ+bMmbJ582YTPrwdP35c0qZNK1mzZvVYrsFG1zm3cQ86zvXOdbHp06ePqTlyXg4fPpxE7wgAAKQ0qX31whowunbtKosXL5Z06dIl62uHhISYCwAAsJ/Pana0merkyZNSoUIFSZ06tbloJ+Rx48aZ21pDo/1uzp496/E4HY2VO3duc1uvvUdnOe87twEAAIHNZ2Gndu3asmPHDtm6davrUqlSJdNZ2Xk7TZo0EhkZ6XrMnj17zFDzqlWrmvt6rc+hoclJa4qyZMkiJUuW9Mn7AgAAKYvPmrEyZ84spUqV8liWMWNGM6eOc3m7du2kR48eEhYWZgLMq6++agLOI488YtbXrVvXhJrWrVvLyJEjTT+dvn37mk7PNFMBAACfhp24GD16tKRKlcpMJqjDxXWk1YcffuhaHxwcLPPnz5eOHTuaEKRhKSIiQgYNGuTTcgMAgJQjRYWd5cuXe9zXjss6Z45eYlOwYEH56aefkqF0AADAH/l8nh0AAIB7ibADAACsRtgBAABWI+wAAACrEXYAAIDVCDsAAMBqhB0AAGA1wg4AALAaYQcAAFiNsAMAAKxG2AEAAFYj7AAAAKsRdgAAgNUIOwAAwGqEHQAAYDXCDgAAsBphBwAAWI2wAwAArEbYAQAAViPsAAAAqxF2AACA1Qg7AADAaoQdAABgNcIOAACwGmEHAABYjbADAACsRtgBAABWI+wAAACrEXYAAIDVCDsAAMBqhB0AAGA1wg4AALAaYQcAAFiNsAMAAKxG2AEAAFYj7AAAAKsRdgAAgNUIOwAAwGqEHQAAYDXCDgAAsBphBwAAWI2wAwAArEbYAQAAViPsAAAAqxF2AACA1Qg7AADAaoQdAABgNcIOAACwGmEHAABYjbADAACsRtgBAABWI+wAAACrEXYAAIDVCDsAAMBqhB0AAGA1wg4AALAaYQcAAFiNsAMAAKxG2AEAAFYj7AAAAKsRdgAAgNUIOwAAwGqEHQAAYDXCDgAAsBphBwAAWI2wAwAArObTsPPRRx9JmTJlJEuWLOZStWpV+fnnn13rr1y5Ip06dZLs2bNLpkyZpFmzZnLixAmP5zh06JA0atRIMmTIIDlz5pSePXvKjRs3fPBuAABASuTTsHP//ffL8OHDJSoqSjZt2iS1atWSp59+Wnbu3GnWd+/eXebNmyezZ8+WFStWyNGjR6Vp06aux9+8edMEnWvXrsmaNWtk6tSpMmXKFOnXr58P3xUAAPDrsLNgwQJZtWqV6/6ECROkXLly8vzzz8uZM2fi9VxPPfWUNGzYUMLDw+XBBx+Ud955x9TgrFu3Ts6dOyeTJk2SUaNGmRBUsWJFmTx5sgk1ul4tWrRIfvvtN5kxY4YpQ4MGDWTw4MGmTBqAYnP16lU5f/68xwUAANgp3mFHm4mc4WDHjh3y2muvmcDy559/So8ePRJcEK2lmTlzply8eNE0Z2ltz/Xr16VOnTqubYoXLy4FChSQtWvXmvt6Xbp0acmVK5drm3r16pnyOWuHYjJs2DAJDQ11XfLnz5/gcgMAAMvCjoaakiVLmtvffvutPPnkkzJ06FBTm+Le3yauNDBpbU5ISIi88sorMnfuXPP8x48fl7Rp00rWrFk9ttdgo+uUXrsHHed657rY9OnTx9QcOS+HDx+Od7kBAIB/SB3fB2gAuXTpkrm9ZMkSadOmjbkdFhaWoOagYsWKydatW03o+OabbyQiIsL0z7mXNFjpBQAA2C/eYad69eqmuapatWqyYcMGmTVrlln++++/mw7HCQlPDzzwgLmt/XI2btwoY8eOlRYtWph+N2fPnvWo3dHRWLlz5za39VrL4M45Wsu5DQAACGzxbsb64IMPJHXq1KYWRoeO58uXzyzXJqz69esnukC3bt0yHYg1+KRJk0YiIyNd6/bs2WOGmmufHqXX2gx28uRJ1zaLFy82w9idTW0AACCwxbtmRzsIz58//7blo0ePjveLa98ZHUGlz3nhwgX58ssvZfny5bJw4ULTcbhdu3amFkmbyDTAvPrqqybgPPLII+bxdevWNaGmdevWMnLkSNNPp2/fvmZuHpqpAABAgsKO2r9/vxkGrtfa5KST+WnNjoaWhx56KM7PozUy2ufn2LFjJtzoBIMadJ544glXgEqVKpWZTFBre3Sk1Ycffuh6fHBwsAleHTt2NCEoY8aMps/PoEGD+HQBAIAR5HA4HBIP2nlYa2O0z87KlStl165dUqRIETM5oE4MqM1b/kY7VmvY0k7SWoMUSAr1/tHXRUAyOjC8Efs7gPD3HVgC8e/7fByP3/Hus9O7d28ZMmSI6RujnYuddOI/52R/AAAAKUW8w452CH7mmWduW65NWadPn06qcgEAAPgm7OgwcO1j423Lli2ukVkAAAB+G3ZatmwpvXr1MiOfgoKCzFDx1atXy+uvv+6aYBAAAMBvw46eGkLPUaXnk4qOjjZDvx977DF59NFHzbBvAAAAvz9dxKeffipvv/22/PrrrybwlC9f3py5HAAAwIp5dpTOqaMXAAAAvw87OotxXI0aNSox5QEAAEj+sKMjreJCOywDAAD4XdhZtmzZvS8JAABAShiNBQAAYH0HZT0H1tdffy2HDh2Sa9eueaybM2dOUpUNAAAg+Wt2Zs6caebU0ROAzp07V65fvy47d+6UpUuXmpNxAQAA+P2kgqNHj5Z58+aZOXfGjh0ru3fvlubNmzMUHQAA+H/Y2b9/vzRq9N/TyGvYuXjxohmF1b17d/nkk0/uRRkBAACSL+xky5ZNLly4YG7riT91FmV19uxZuXTpUsJLAgAAkBI6KOt5sBYvXiylS5eWZ599Vrp27Wr66+iy2rVr34syAgAAJF/Y+eCDD+TKlSvm9ltvvSVp0qSRNWvWSLNmzTgRKAAA8P+wExYW5rqdKlUq6d27d1KXCQAAIPnDzo0bN+TmzZsSEhLiWnbixAmZOHGi6aTcuHFjqV69etKVDAAAIDnDTvv27c3oq48//tjc107KDz/8sGnSypMnjxmO/v3330vDhg2TolwAAADJOxpr9erVpl+O07Rp00xNz969e2Xbtm3mzOjvvvtu0pQKAAAgucPOkSNHJDw83HU/MjLShB/nrMkRERFmJmUAAAC/DDvp0qWTy5cvu+6vW7dOqlSp4rE+Ojo66UsIAACQHGGnXLlyMn36dHP7l19+MZ2Ta9Wq5TGzct68eRNTFgAAAN91UO7Xr580aNDAnO382LFj8uKLL5qOyU56UtBq1aolfQkBAACSI+zUqFFDoqKiZNGiRZI7d24ze7J3zU/lypUTUxYAAADfTipYokQJc4nJyy+/nFRlAgAA8N2JQAEAAPwJYQcAAFiNsAMAAKxG2AEAAFZLUNg5e/asfPbZZ9KnTx/5559/zLLNmzebWZYBAAD8djSW2r59u9SpU8ecJuLAgQPmBKFhYWEyZ84cOXTokDlnFgAAgN/W7OgJP3VCQT0BqJ4iwknPdr5y5cqkLh8AAEDyhp2NGzdKhw4dblueL18+OX78eOJKAwAA4OuwExISIufPn79t+e+//y733XdfUpULAAAgScQ77DRu3FgGDRok169fN/eDgoJMX51evXpJs2bNkqZUAAAAvgo777//vkRHR0vOnDnl8uXL5pxZDzzwgGTOnFneeeedpCoXAACAb0Zj6SisxYsXy6pVq8zILA0+FSpUMCO0AAAA/D7sOFWvXt1cAAAArAo748aNi3G59t3RoejapPXYY49JcHBwUpQPAAAgecPO6NGj5dSpU3Lp0iXJli2bWXbmzBnJkCGDZMqUSU6ePClFihSRZcuWSf78+RNXOgAAgOTuoDx06FB5+OGHzaSCf//9t7nosPMqVarI2LFjzcis3LlzS/fu3RNbNgAAgOSv2enbt698++23UrRoUdcybbp67733zNDzP/74Q0aOHMkwdAAA4J81O8eOHZMbN27ctlyXOWdQzps3r1y4cCFpSggAAJCcYadmzZrmdBFbtmxxLdPbHTt2lFq1apn7O3bskMKFCyemXAAAAL4JO5MmTTJnOa9YsaI5dYReKlWqZJbpOqUdlXXyQQAAAL/rs6Odj3VSwd27d5uOyapYsWLm4l77AwAA4NeTChYvXtxcAAAArAs7f/31l/zwww9mmPm1a9c81o0aNSqpygYAAJD8YScyMtKc+VwnDtSmrFKlSsmBAwfE4XCYc2QBAAD4dQflPn36yOuvv25GXOnpIXTOncOHD5uznz/77LP3ppQAAADJFXZ27dolbdq0MbdTp04tly9fNqOvBg0aJCNGjEhoOQAAAFJG2MmYMaOrn06ePHlk//79rnWnT59O2tIBAAAkd5+dRx55RFatWiUlSpSQhg0bymuvvWaatObMmWPWAQAA+HXY0dFW0dHR5vbAgQPN7VmzZkl4eDgjsQAAgH+HnZs3b5ph52XKlHE1aU2cOPFelQ0AACB5++wEBwdL3bp15cyZM4l/ZQAAgJTYQVnn1fnjjz/uTWkAAAB8HXaGDBli5tmZP3++HDt2TM6fP+9xAQAA8OsOyjoCS+ksykFBQa7lOoOy3td+PQAAAH4bdpYtW3ZvSgIAAJASwo6eFgIAAMDaPjvql19+kRdeeEEeffRROXLkiFk2ffp0M9kgAACAX4cdPfFnvXr1JH369LJ582a5evWqWX7u3DkZOnTovSgjAABA8o7G0okEP/30U0mTJo1rebVq1Uz4iY9hw4bJww8/LJkzZ5acOXNKkyZNZM+ePR7bXLlyRTp16iTZs2c3Jxxt1qyZnDhxwmObQ4cOSaNGjSRDhgzmeXr27Ck3btyI71sDAAAWinfY0TDy2GOP3bY8NDRUzp49G6/nWrFihQky69atk8WLF8v169fNpIUXL150bdO9e3eZN2+ezJ4922x/9OhRadq0qWu9jv7SoKMnJ12zZo1MnTpVpkyZIv369YvvWwMAABaKdwfl3Llzy759+6RQoUIey7W/TpEiReL1XAsWLPC4ryFFa2aioqJMoNKmsUmTJsmXX34ptWrVMttMnjzZnIRUA5KeeHTRokXy22+/yZIlSyRXrlxSrlw5GTx4sPTq1UsGDBggadOmve11tenN2fymmB8IAAB7xbtmp3379tK1a1dZv369mVdHa1q++OILM9Fgx44dE1UYDTcqLCzMXGvo0dqeOnXquLYpXry4FChQQNauXWvu63Xp0qVN0HHSPkUaYHbu3Blr85nWRDkv+fPnT1S5AQCARTU7vXv3llu3bknt2rXl0qVLpgYmJCTEhJ1XX301wQXR5+zWrZvp+6OnpFDHjx83NTNZs2b12FaDja5zbuMedJzrneti0qdPH+nRo4frvgYjAg8AAHaKd9jR2py33nrLdALW5qzo6GgpWbKk6TycGNp359dff02W4esazvQCAADsF+9mrBkzZpgaHa1x0ZBTuXLlRAedzp07m3Nt6ezM999/v0f/IO147N3xWUdj6TrnNt6js5z3ndsAAIDAFe+wo6OjtBPx888/Lz/99FOizoWl59PSoDN37lxZunSpFC5c2GN9xYoVzfD2yMhIj9FgOtS8atWq5r5e79ixQ06ePOnaRkd2ZcmSxYQxAAAQ2OIddvRM5zNnzjTNWc2bN5c8efKYJigd9h1f+jitKdLRVjrXjvax0cvly5fNeu083K5dO9O/Rmt9tMNy27ZtTcDRkVhKh6prqGndurVs27ZNFi5cKH379jXPTVMVAACId9hJnTq1PPnkk2YEltamjB49Wg4cOCA1a9aUokWLxuu5PvroIzMC6/HHHzehyXmZNWuWaxt9fn09nUxQO0Nr09ScOXNc64ODg00TmF5rCNLTWLRp00YGDRrEpwsAAOLfQdmdzlisw7zPnDkjBw8elF27dsW7Getu0qVLJxMmTDCX2BQsWNA0qQEAACTJiUC1g7LW7DRs2FDy5csnY8aMkWeeeSbWeW0AAAD8pmanZcuWptlIa3W0z87bb7/t6iwMAADg92FH+8Z8/fXXpvlKb7vTeXKcEwICAAD4ZdjR5it3Fy5ckK+++ko+++wzM1oqMUPRAQAAUkSfHbVy5UqJiIgwo6fee+89c6JOPTknAACA39bs6Bw4emZyPRO5nk9K++zo2cO/++47JvADAAD+XbPz1FNPSbFixWT79u1m9JWe7Xz8+PH3tnQAAADJVbPz888/S5cuXaRjx44SHh6e2NcFAABIWTU7ejZy7Yys56uqUqWKfPDBB3L69Ol7WzoAAIDkCjt6LqpPP/3UnBurQ4cO5vxYefPmlVu3bpkTb2oQAgAA8PvRWBkzZpSXXnrJ1PTo2cZfe+01GT58uDkTeuPGje9NKQEAAJJ76LnSDssjR46Uv/76y8y1AwAAYFXYcdKZlJs0aSI//PBDUjwdAABAygo7AAAAKRVhBwAAWI2wAwAArEbYAQAAViPsAAAAqxF2AACA1Qg7AADAaoQdAABgNcIOAACwGmEHAABYjbADAACsRtgBAABWI+wAAACrEXYAAIDVCDsAAMBqhB0AAGA1wg4AALAaYQcAAFiNsAMAAKxG2AEAAFYj7AAAAKsRdgAAgNUIOwAAwGqEHQAAYDXCDgAAsBphBwAAWI2wAwAArEbYAQAAViPsAAAAqxF2AACA1Qg7AADAaoQdAABgNcIOAACwGmEHAABYjbADAACsRtgBAABWI+wAAACrEXYAAIDVCDsAAMBqhB0AAGA1wg4AALAaYQcAAFiNsAMAAKxG2AEAAFYj7AAAAKsRdgAAgNUIOwAAwGqEHQAAYDXCDgAAsBphBwAAWI2wAwAArEbYAQAAVvNp2Fm5cqU89dRTkjdvXgkKCpLvvvvOY73D4ZB+/fpJnjx5JH369FKnTh3Zu3evxzb//POPtGrVSrJkySJZs2aVdu3aSXR0dDK/EwAAkFL5NOxcvHhRypYtKxMmTIhx/ciRI2XcuHEyceJEWb9+vWTMmFHq1asnV65ccW2jQWfnzp2yePFimT9/vglQL7/8cjK+CwAAkJKl9uWLN2jQwFxiorU6Y8aMkb59+8rTTz9tlk2bNk1y5cplaoBatmwpu3btkgULFsjGjRulUqVKZpvx48dLw4YN5b333jM1RgAAILCl2D47f/75pxw/ftw0XTmFhoZKlSpVZO3atea+XmvTlTPoKN0+VapUpiYoNlevXpXz5897XAAAgJ1SbNjRoKO0Jsed3neu0+ucOXN6rE+dOrWEhYW5tonJsGHDTHByXvLnz39P3gMAAPC9FBt27qU+ffrIuXPnXJfDhw/7ukgAACDQwk7u3LnN9YkTJzyW633nOr0+efKkx/obN26YEVrObWISEhJiRm+5XwAAgJ1SbNgpXLiwCSyRkZGuZdq3RvviVK1a1dzX67Nnz0pUVJRrm6VLl8qtW7dM3x4AAACfjsbS+XD27dvn0Sl569atps9NgQIFpFu3bjJkyBAJDw834eftt982I6yaNGliti9RooTUr19f2rdvb4anX79+XTp37mxGajESCwAA+DzsbNq0SWrWrOm636NHD3MdEREhU6ZMkTfeeMPMxaPz5mgNTvXq1c1Q83Tp0rke88UXX5iAU7t2bTMKq1mzZmZuHgAAABXk0AltApw2j+moLO2sHGj9dwr1/tHXRUAyOjC8Efs7gPD3HVgC8e/7fByP3ym2zw4AAEBSIOwAAACrEXYAAIDVCDsAAMBqhB0AAGA1wg4AALAaYQcAAFiNsAMAAKxG2AEAAFYj7AAAAKsRdgAAgNUIOwAAwGqEHQAAYDXCDgAAsBphBwAAWI2wAwAArEbYAQAAViPsAAAAqxF2AACA1Qg7AADAaoQdAABgNcIOAACwGmEHAABYjbADAACsRtgBAABWI+wAAACrEXYAAIDVCDsAAMBqhB0AAGA1wg4AALAaYQcAAFiNsAMAAKxG2AEAAFYj7AAAAKsRdgAAgNUIOwAAwGqEHQAAYDXCDgAAsBphBwAAWI2wAwAArEbYAQAAViPsAAAAqxF2AACA1Qg7AADAaoQdAABgNcIOAACwGmEHAABYjbADAACsRtgBAABWI+wAAACrEXYAAIDVCDsAAMBqhB0AAGA1wg4AALAaYQcAAFiNsAMAAKxG2AEAAFYj7AAAAKsRdgAAgNUIOwAAwGqEHQAAYDXCDgAAsBphBwAAWI2wAwAArEbYAQAAViPsAAAAq1kTdiZMmCCFChWSdOnSSZUqVWTDhg2+LhIAAEgBrAg7s2bNkh49ekj//v1l8+bNUrZsWalXr56cPHnS10UDAAA+ZkXYGTVqlLRv317atm0rJUuWlIkTJ0qGDBnk888/93XRAACAj6UWP3ft2jWJioqSPn36uJalSpVK6tSpI2vXro3xMVevXjUXp3Pnzpnr8+fPS6C5dfWSr4uAZBSI3/FAxt93YAnEv+/z/3vPDofD7rBz+vRpuXnzpuTKlctjud7fvXt3jI8ZNmyYDBw48Lbl+fPnv2flBFKC0DG+LgGAeyWQ/74vXLggoaGh9oadhNBaIO3j43Tr1i35559/JHv27BIUFOTTsiF5fglosD18+LBkyZKFXQ5YhL/vwOJwOEzQyZs37x238/uwkyNHDgkODpYTJ054LNf7uXPnjvExISEh5uIua9as97ScSHk06BB2ADvx9x04Qu9Qo2NNB+W0adNKxYoVJTIy0qOmRu9XrVrVp2UDAAC+5/c1O0qbpCIiIqRSpUpSuXJlGTNmjFy8eNGMzgIAAIHNirDTokULOXXqlPTr10+OHz8u5cqVkwULFtzWaRlQ2oSpczJ5N2UC8H/8fSMmQY67jdcCAADwY37fZwcAAOBOCDsAAMBqhB0AAGA1wg4AALAaYQcAAFiNsAMAAKxG2AEAAFazYlJBILYTAsYV58gC/NvGjRtl2bJlcvLkSXPKIHejRo3yWbmQMhB2YC09uevdzmKvc2rqNjdv3ky2cgFIWkOHDpW+fftKsWLFzMz57n/3d/s/AIGBGZRhrRUrVsR52xo1atzTsgC4dzTgjBgxQl588UV2M2JEzQ6sRYABAkOqVKmkWrVqvi4GUjBqdhBQLl26JIcOHZJr1655LC9TpozPygQgcUaOHClHjx6VMWPGsCsRI8IOAsKpU6ekbdu28vPPP8e4nj47gP/SDsmNGjWS33//XUqWLClp0qTxWD9nzhyflQ0pA0PPERC6desmZ8+elfXr10v69OllwYIFMnXqVAkPD5cffvjB18UDkAhdunQxI7EefPBByZ49u4SGhnpcAGp2EBDy5Mkj33//vVSuXNkMM9+0aZP5j1GDjlaBr1q1ytdFBJBAmTNnlpkzZ5raHSAm1OwgIFy8eFFy5sxpbmfLls00a6nSpUvL5s2bfVw6AIkRFhYmRYsWZSciVoQdBASdf2PPnj3mdtmyZeXjjz+WI0eOyMSJE02tDwD/NWDAAOnfv78ZgADEhGYsBIQZM2bIjRs3zDwcUVFRUr9+ffnnn38kbdq0MmXKFGnRooWviwgggcqXLy/79+83k4QWKlTotg7K1N6CeXYQEF544QXX7YoVK8rBgwdl9+7dUqBAAcmRI4dPywYgcZo0acIuxB1RswMAAKxGzQ4CglZvf/PNN7GeKJB5OADAXoQdBMw8O9opuWbNmredKBCA/58u4k5/00waCsIOAsL06dNN7U3Dhg19XRQASWzu3Lke969fvy5btmwxE4cOHDiQ/Q367CAwFC5c2Jwqonjx4r4uCoBk8uWXX8qsWbPMhKIIbHRQRkDQX3h6iojPP//cnC4CgP3++OMPc5Lf6OhoXxcFPkYzFgJC8+bN5auvvjKzKDMPB2C/y5cvy7hx4yRfvny+LgpSAMIOAkJERISZTFDn26GDMmAXPQWMewdlHX154cIFyZAhg5lQFKAZCwEhY8aMsnDhQqlevbqviwIgieks6O5hR0dn3XfffVKlShUThABqdhAQ8ufPb852DsA+ehoY4E6o2UFA+PHHH2X8+PHmxJ/aZweAf9u+fbuUKlXK1OLo7TvRTsoIbIQdBAStytYzIuvJQLUd3/tEgXpSUAD+Q0PO8ePHzaAD56SC2lfHmy5nUkHQjIWAMGbMGF8XAUAS+vPPP02/HOdt4E6o2YH1dDbVDh06yNtvv20mFwQABBbCDgJCaGiobN26lbADWOro0aOyatWqGE/026VLF5+VCykDYQcBM89OuXLlpHv37r4uCoB7MPRca2/Tpk0r2bNn9xiGrrd1JmUENsIOAsKQIUPk/fffl9q1a0vFihXNvDvu+OUH+PfUEq+88or06dPHdFYGvBF2EBDu1FeHX36Af9PanA0bNkjRokV9XRSkUIQdAIBfe+ONNyQsLEx69+7t66IghSLsIOA45+Jwb9cH4L90Hp0nn3zSnPyzdOnSt82jNWrUKJ+VDSkD8+wgYEybNk3effdd2bt3r7n/4IMPSs+ePaV169a+LhqARBg2bJg5912xYsXMfe8OygBhBwFBf9npPDudO3eWatWqmWU6TFU7NZ4+fZpRWoAf08EHn3/+OefIQqxoxkLAdFAeOHCgtGnTxmP51KlTZcCAAczACvix3Llzyy+//CLh4eG+LgpSKMboISAcO3ZMHn300duW6zJdB8B/de3a1ZzoF4gNzVgICA888IB8/fXX8uabb3osnzVrFr8GAT+nw86XLl0q8+fPl4ceeui2Dspz5szxWdmQMhB2EBC0CatFixaycuVKV5+d1atXS2RkpAlBAPxX1qxZpWnTpr4uBlIw+uwgYERFRZmOyrt37zb3S5QoIa+99pqUL1/e10UDANxDhB0AgN+7ceOGLF++XPbv3y/PP/+8ZM6c2ZwcNEuWLJIpUyZfFw8+RtiB1fQ8OXebZ0PX63+UAPzTwYMHpX79+nLo0CG5evWq/P7771KkSBHTcVnvT5w40ddFhI/RZwdWmzt3bqzr1q5dK+PGjZNbt24la5kAJC0NNZUqVZJt27aZ82Q5PfPMM9K+fXt2Nwg7sNvTTz9927I9e/aYc+jMmzdPWrVqJYMGDfJJ2QAkDZ1jZ82aNZI2bVqP5YUKFZIjR46wm8E8Owgc2n6vv/L03DnabLV161YzqWDBggV9XTQAiaC1s3p+LG9//fWX6bsDMKkgrHfu3Dnp1auXmWtn586dZri51uqUKlXK10UDkATq1q0rY8aM8eiHFx0dLf3795eGDRuyj0EHZdht5MiRMmLECDOd/NChQ2Ns1gLg3w4fPmw6KDscDnOiX+2/o9c5cuQwc2vlzJnT10WEjzEaC9aPxkqfPr3UqVNHgoODY92OGVYB/6ZN0zojunZS1lqdChUqmD55+vcPEHZgtRdffPGuQ8/V5MmTk6U8AJLW9evXpXjx4uZUETpRKBAThp7DalOmTPF1EQDcQ3oerCtXrrCPcUd0UAYA+LVOnTqZvnlMDorY0IwFAPBrOnmgjrLU00Lo1BIZM2b0WE+fPNCMBQDw+7OeN2vWzNfFQApG2AEA+O1kgu+++645F9a1a9ekVq1aMmDAAEZg4Tb02QEA+KV33nlH3nzzTdN8lS9fPnOuO+2/A3ijzw4AwC+Fh4fL66+/Lh06dDD3lyxZIo0aNZLLly+bObYAJ8IOAMAvhYSEyL59+yR//vyuZenSpTPL7r//fp+WDSkL0RcA4Jd0qLmGG+95d3SiQcAdHZQBAH5Jz4Wls6RrDY+TTjD4yiuveAw/Z+g5CDsAAL8UERFx27IXXnjBJ2VBykafHQAAYDX67AAAAKsRdgAAgNUIOwAAwGqEHQAAYDXCDgC/9vjjj0u3bt2S/XX1HEzlypVLkWUD4ImwAyDBdI6ToKAgM6+JNz1Hka7TbQKVzu8yePBgXxcDCHiEHQCJolP1z5w505yPyH1ity+//FIKFCjgl3v35s2b5ozaiRUWFiaZM2dOkjIBSDjCDoBEqVChggk87rPU6m0NOuXLl3ct0/AwbNgwKVy4sKRPn17Kli0r33zzjWv98uXLTU3QwoULzeN0m1q1asnJkyfl559/lhIlSkiWLFnk+eefl0uXLt122oDOnTtLaGio5MiRQ95++20zu67T1atXzQkj9czYOrNulSpVzOs5TZkyRbJmzSo//PCDlCxZ0szIe+jQIbNN5cqVzWN0fbVq1eTgwYMerz19+nQpVKiQee2WLVvKhQsXYm3G0u20pue5554zz6nlmTBhAt9A4B4j7ABItJdeekkmT57suv/5559L27ZtPbbRoDNt2jSZOHGi7Ny5U7p3725mu12xYsVtfWE++OADWbNmjRw+fFiaN28uY8aMMTVFP/74oyxatEjGjx/v8ZipU6dK6tSpZcOGDTJ27FgZNWqUfPbZZ671GoTWrl1raqC2b98uzz77rNSvX1/27t3r2kYD1IgRI8zjtHxaK9OkSROpUaOGeYw+/uWXXzaBzGn//v3y3Xffyfz5881F38vw4cPvuK/effddE/S2bNkivXv3lq5du8rixYsTsNcBxJkDABIoIiLC8fTTTztOnjzpCAkJcRw4cMBc0qVL5zh16pRZp9tcuXLFkSFDBseaNWs8Ht+uXTvHc889Z24vW7ZMq2IcS5Ysca0fNmyYWbZ//37Xsg4dOjjq1avnul+jRg1HiRIlHLdu3XIt69Wrl1mmDh486AgODnYcOXLE47Vr167t6NOnj7k9efJk8zpbt251rf/777/NsuXLl8f43vv372/e0/nz513Levbs6ahSpYpH2bp27eq6X7BgQUf9+vU9nqdFixaOBg0a3HE/A0gczo0FINHuu+8+adSokWkO0uYjva3NSU779u0zNSdPPPGEx+OuXbvm0dSlypQp47qdK1cuyZAhgxQpUsRjmdbguHvkkUc8alyqVq0q77//vul7s2PHDnP94IMPejxGm7ayZ8/uup82bVqP19aaHe1cXa9ePVPuOnXqmFqmPHnyeDRLuffJ0XXa7HYnWjbv+1pzBeDeIewASLKmLG0uUt79UKKjo821NkNpPxV37mesVmnSpHHd1gDjft+5LD6dh/W1g4ODJSoqyly7y5Qpk+u29hFyD0xKm+a6dOkiCxYskFmzZknfvn1Nk5OGK++yJqRsAJIHYQdAktA+MFpTowd8rQ1x597pV/vAJLX169d73F+3bp2Eh4ebcKM1R1qzozUu//rXv+L93Pp4vfTp08fUwmjfIWfYSQgtm/d97XwN4N4h7ABIEhosdu3a5brtTpt6dDSUdkrWmo/q1avLuXPnZPXq1WaEVURERKJeW0NUjx49pEOHDrJ582bTgVmbsZQ2X7Vq1UratGljlmlwOXXqlERGRppmK21yi8mff/4pn3zyiTRu3Fjy5s0re/bsMR2a9XkSQ9/zyJEjTednrSWaPXu2qfECcO8QdgAkGQ0usdEh19q3R0dl/fHHH2Yotw5bf/PNNxP9uhpAdJ4fHSauQUtHOOnIKffmqCFDhshrr70mR44cMf2JtHbmySefjPU5ta/Q7t27zUivv//+2/TH0YkSNVAlhpZh06ZNMnDgQLO/dOSYd00YgKQVpL2Uk/g5AQAx0A7NOu8Op5AAkhfz7AAAAKsRdgAAgNVoxgIAAFajZgcAAFiNsAMAAKxG2AEAAFYj7AAAAKsRdgAAgNUIOwAAwGqEHQAAYDXCDgAAsNr/A64crqpt69wuAAAAAElFTkSuQmCC",
+      "text/plain": [
+       "<Figure size 640x480 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "avg_sales.plot(kind=\"bar\")\n",
+    "plt.title(\"Average Sales by Membership\")\n",
+    "plt.xlabel(\"Membership\")\n",
+    "plt.ylabel(\"Average Sales\")\n",
+    "plt.ticklabel_format(style='plain', axis='y')\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c36c19d3",
+   "metadata": {},
+   "source": [
+    "# Conclusion\n",
+    "The analysis clearly indicates that Premium membership is a critical driver of revenue for this e-commerce platform. While Normal members contribute a healthy $22.7M, the Premium tier generates the bulk of the sales at $48.4M"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.14.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This pull request implements a complete sales analysis based on membership type (Normal vs Premium). It includes data grouping, visualization, and insights on how different membership types impact overall revenue.

📈 Plots Added


1️⃣ Total Sales by Membership Type
<img width="615" height="502" alt="output" src="https://github.com/user-attachments/assets/30932790-b590-4c99-8248-a0141a204bba" />

2️⃣ Average Sales by Membership Type
<img width="571" height="502" alt="outputbcvb" src="https://github.com/user-attachments/assets/cd05006a-4fe9-4951-93b2-96a3a6795ff8" />

🧠 Key Insight
Although the average sales per transaction for Normal and Premium members are very close, Premium members generate higher total revenue due to higher purchase frequency. This suggests that Premium users are more engaged rather than spending significantly more per purchase.